### PR TITLE
Phase 1 — Data plumbing: providers, recorder, replay, historical cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,16 @@ dist/
 !.env.example
 
 # Trading data + runtime artifacts
-data/
+/data/
+/recordings/
 logs/
 *.log
 *.csv
 *.parquet
+*.sqlite
+*.sqlite-journal
+*.sqlite-wal
+*.sqlite-shm
 
 # OS
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ files = ["src", "tests"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "integration: end-to-end tests that exercise multiple data-layer components together",
+]

--- a/src/ross_trading/core/clock.py
+++ b/src/ross_trading/core/clock.py
@@ -1,1 +1,87 @@
-"""ET timezone, market-hours, pre-market window helpers. See issue #1, arch §3.1."""
+"""Clock abstraction.
+
+Production code uses :class:`RealClock`. Tests and historical replay use
+:class:`VirtualClock` so deterministic playback doesn't depend on
+wall-clock time. Every component that timestamps events or schedules
+work should accept a ``Clock`` rather than calling ``datetime.now()``
+or ``asyncio.sleep`` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Clock(Protocol):
+    """Sourcing tz-aware UTC time + a sleep primitive."""
+
+    def now(self) -> datetime: ...
+
+    def monotonic(self) -> float: ...
+
+    async def sleep(self, seconds: float) -> None: ...
+
+
+class RealClock:
+    """Wall-clock implementation."""
+
+    def now(self) -> datetime:
+        return datetime.now(UTC)
+
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+    async def sleep(self, seconds: float) -> None:
+        await asyncio.sleep(seconds)
+
+
+class VirtualClock:
+    """In-memory clock for replay and tests.
+
+    ``sleep`` does not block on wall time; it advances the virtual time
+    by the requested duration and yields control once so cooperating
+    coroutines can interleave.
+    """
+
+    def __init__(self, start: datetime) -> None:
+        if start.tzinfo is None:
+            msg = "VirtualClock requires a tz-aware start time"
+            raise ValueError(msg)
+        self._now = start.astimezone(UTC)
+        self._monotonic = 0.0
+
+    def now(self) -> datetime:
+        return self._now
+
+    def monotonic(self) -> float:
+        return self._monotonic
+
+    async def sleep(self, seconds: float) -> None:
+        if seconds < 0:
+            msg = "sleep duration must be non-negative"
+            raise ValueError(msg)
+        self.advance(seconds)
+        await asyncio.sleep(0)
+
+    def advance(self, seconds: float) -> None:
+        if seconds < 0:
+            msg = "advance duration must be non-negative"
+            raise ValueError(msg)
+        self._now = self._now + timedelta(seconds=seconds)
+        self._monotonic += seconds
+
+    def set_time(self, when: datetime) -> None:
+        if when.tzinfo is None:
+            msg = "set_time requires a tz-aware datetime"
+            raise ValueError(msg)
+        target = when.astimezone(UTC)
+        delta = (target - self._now).total_seconds()
+        if delta < 0:
+            msg = f"clock cannot move backwards (current={self._now}, target={target})"
+            raise ValueError(msg)
+        self._now = target
+        self._monotonic += delta

--- a/src/ross_trading/core/errors.py
+++ b/src/ross_trading/core/errors.py
@@ -1,1 +1,31 @@
-"""Error hierarchy. See issue #1."""
+"""Error hierarchy.
+
+Phase 1 introduces the data-layer errors below. Other phases extend
+``TradingError`` with their own subclasses (risk, execution, etc.).
+"""
+
+from __future__ import annotations
+
+
+class TradingError(Exception):
+    """Root of all domain-specific exceptions in the agent."""
+
+
+class FeedError(TradingError):
+    """Anything that goes wrong inside the read-side data layer."""
+
+
+class FeedDisconnected(FeedError):
+    """The provider's transport dropped; reconnect logic should engage."""
+
+
+class FeedGapError(FeedError):
+    """A gap window could not be backfilled within the configured budget."""
+
+
+class MissingRecordingError(FeedError):
+    """Replay was asked for data that is not present on disk."""
+
+
+class RateLimitError(FeedError):
+    """The vendor signalled a rate-limit response; backoff is required."""

--- a/src/ross_trading/data/__init__.py
+++ b/src/ross_trading/data/__init__.py
@@ -1,0 +1,24 @@
+"""Read-side data layer: market quotes, bars, news, float reference.
+
+See issue #2 (Phase 1 — Data plumbing) and architecture doc §3.1.
+"""
+
+from ross_trading.data.types import (
+    Bar,
+    FeedGap,
+    FloatRecord,
+    Headline,
+    Quote,
+    Side,
+    Tape,
+)
+
+__all__ = [
+    "Bar",
+    "FeedGap",
+    "FloatRecord",
+    "Headline",
+    "Quote",
+    "Side",
+    "Tape",
+]

--- a/src/ross_trading/data/_codec.py
+++ b/src/ross_trading/data/_codec.py
@@ -24,6 +24,11 @@ from ross_trading.data.types import Bar, FloatRecord, Headline, Quote, Side, Tap
 
 SCHEMA_VERSION = 1
 
+# Versions a current build can still decode. New schemas append to this set
+# as they're introduced; the corresponding decoders must dispatch on the
+# version field and accept old payloads forever.
+SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1})
+
 
 class EventType(StrEnum):
     QUOTE = "quote"
@@ -45,8 +50,10 @@ def encode_event(event_type: EventType, payload: dict[str, Any], ts_recorded: da
 
 def decode_envelope(line: str) -> tuple[EventType, dict[str, Any]]:
     obj = json.loads(line)
-    if obj.get("_schema") != SCHEMA_VERSION:
-        msg = f"unsupported schema version: {obj.get('_schema')!r}"
+    version = obj.get("_schema")
+    if version not in SUPPORTED_SCHEMA_VERSIONS:
+        supported = sorted(SUPPORTED_SCHEMA_VERSIONS)
+        msg = f"unsupported schema version: {version!r} (supported: {supported})"
         raise ValueError(msg)
     return EventType(obj["type"]), obj["payload"]
 

--- a/src/ross_trading/data/_codec.py
+++ b/src/ross_trading/data/_codec.py
@@ -1,0 +1,161 @@
+"""JSON serialization shared by :mod:`recorder` and :mod:`providers.replay`.
+
+Wire format:
+
+::
+
+    {"_schema": 1, "ts_recorded": "<iso>", "type": "<EventType>",
+     "payload": {<event-specific fields>}}
+
+Each on-disk file holds a single ``EventType`` so readers don't need
+to dispatch line-by-line. Decimals are encoded as strings to preserve
+exact precision; datetimes use ISO-8601 with explicit UTC offset.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any
+
+from ross_trading.data.types import Bar, FloatRecord, Headline, Quote, Side, Tape
+
+SCHEMA_VERSION = 1
+
+
+class EventType(StrEnum):
+    QUOTE = "quote"
+    BAR = "bar"
+    TAPE = "tape"
+    HEADLINE = "headline"
+    FLOAT = "float"
+
+
+def encode_event(event_type: EventType, payload: dict[str, Any], ts_recorded: datetime) -> str:
+    envelope = {
+        "_schema": SCHEMA_VERSION,
+        "ts_recorded": ts_recorded.isoformat(),
+        "type": event_type.value,
+        "payload": payload,
+    }
+    return json.dumps(envelope, separators=(",", ":"))
+
+
+def decode_envelope(line: str) -> tuple[EventType, dict[str, Any]]:
+    obj = json.loads(line)
+    if obj.get("_schema") != SCHEMA_VERSION:
+        msg = f"unsupported schema version: {obj.get('_schema')!r}"
+        raise ValueError(msg)
+    return EventType(obj["type"]), obj["payload"]
+
+
+def encode_quote(q: Quote) -> dict[str, Any]:
+    return {
+        "symbol": q.symbol,
+        "ts": q.ts.isoformat(),
+        "bid": str(q.bid),
+        "ask": str(q.ask),
+        "bid_size": q.bid_size,
+        "ask_size": q.ask_size,
+    }
+
+
+def decode_quote(p: dict[str, Any]) -> Quote:
+    return Quote(
+        symbol=p["symbol"],
+        ts=datetime.fromisoformat(p["ts"]),
+        bid=Decimal(p["bid"]),
+        ask=Decimal(p["ask"]),
+        bid_size=int(p["bid_size"]),
+        ask_size=int(p["ask_size"]),
+    )
+
+
+def encode_bar(b: Bar) -> dict[str, Any]:
+    return {
+        "symbol": b.symbol,
+        "ts": b.ts.isoformat(),
+        "timeframe": b.timeframe,
+        "open": str(b.open),
+        "high": str(b.high),
+        "low": str(b.low),
+        "close": str(b.close),
+        "volume": b.volume,
+    }
+
+
+def decode_bar(p: dict[str, Any]) -> Bar:
+    return Bar(
+        symbol=p["symbol"],
+        ts=datetime.fromisoformat(p["ts"]),
+        timeframe=p["timeframe"],
+        open=Decimal(p["open"]),
+        high=Decimal(p["high"]),
+        low=Decimal(p["low"]),
+        close=Decimal(p["close"]),
+        volume=int(p["volume"]),
+    )
+
+
+def encode_tape(t: Tape) -> dict[str, Any]:
+    return {
+        "symbol": t.symbol,
+        "ts": t.ts.isoformat(),
+        "price": str(t.price),
+        "size": t.size,
+        "side": t.side.value,
+    }
+
+
+def decode_tape(p: dict[str, Any]) -> Tape:
+    return Tape(
+        symbol=p["symbol"],
+        ts=datetime.fromisoformat(p["ts"]),
+        price=Decimal(p["price"]),
+        size=int(p["size"]),
+        side=Side(p.get("side", Side.UNKNOWN.value)),
+    )
+
+
+def encode_headline(h: Headline) -> dict[str, Any]:
+    return {
+        "ticker": h.ticker,
+        "ts": h.ts.isoformat(),
+        "source": h.source,
+        "title": h.title,
+        "url": h.url,
+        "body": h.body,
+    }
+
+
+def decode_headline(p: dict[str, Any]) -> Headline:
+    return Headline(
+        ticker=p["ticker"],
+        ts=datetime.fromisoformat(p["ts"]),
+        source=p["source"],
+        title=p["title"],
+        url=p.get("url"),
+        body=p.get("body"),
+    )
+
+
+def encode_float(r: FloatRecord) -> dict[str, Any]:
+    return {
+        "ticker": r.ticker,
+        "as_of": r.as_of.isoformat(),
+        "float_shares": r.float_shares,
+        "shares_outstanding": r.shares_outstanding,
+        "source": r.source,
+    }
+
+
+def decode_float(p: dict[str, Any]) -> FloatRecord:
+    return FloatRecord(
+        ticker=p["ticker"],
+        as_of=date.fromisoformat(p["as_of"]),
+        float_shares=int(p["float_shares"]),
+        shares_outstanding=int(p["shares_outstanding"]),
+        source=p["source"],
+    )

--- a/src/ross_trading/data/cache.py
+++ b/src/ross_trading/data/cache.py
@@ -1,0 +1,167 @@
+"""SQLite-backed historical-data cache.
+
+Two tables:
+
+* ``daily_volumes(symbol, as_of, volume)`` — one row per (symbol, day);
+  feeds 30-day relative-volume calculations (architecture §3.1).
+* ``daily_emas(symbol, as_of, period, value)`` — one row per
+  (symbol, day, period); feeds the daily-strength filter (§3.3).
+
+The store is opened in WAL mode so concurrent readers don't block
+writers. Decimal values are persisted as strings to preserve precision.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS daily_volumes (
+    symbol TEXT NOT NULL,
+    as_of TEXT NOT NULL,
+    volume INTEGER NOT NULL,
+    PRIMARY KEY (symbol, as_of)
+);
+CREATE TABLE IF NOT EXISTS daily_emas (
+    symbol TEXT NOT NULL,
+    as_of TEXT NOT NULL,
+    period INTEGER NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (symbol, as_of, period)
+);
+"""
+
+
+class HistoricalCache:
+    """Thin SQLite wrapper. Synchronous — calls are sub-millisecond."""
+
+    def __init__(self, db_path: Path | str = ":memory:") -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> HistoricalCache:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def record_daily_volume(self, symbol: str, as_of: date, volume: int) -> None:
+        with closing(self._conn.cursor()) as cur:
+            cur.execute(
+                "INSERT OR REPLACE INTO daily_volumes(symbol, as_of, volume) VALUES (?, ?, ?)",
+                (symbol.upper(), as_of.isoformat(), int(volume)),
+            )
+        self._conn.commit()
+
+    def record_daily_volumes(
+        self,
+        rows: Iterable[tuple[str, date, int]],
+    ) -> None:
+        materialized = [(s.upper(), d.isoformat(), int(v)) for s, d, v in rows]
+        if not materialized:
+            return
+        with closing(self._conn.cursor()) as cur:
+            cur.executemany(
+                "INSERT OR REPLACE INTO daily_volumes(symbol, as_of, volume) VALUES (?, ?, ?)",
+                materialized,
+            )
+        self._conn.commit()
+
+    def daily_volume(self, symbol: str, as_of: date) -> int | None:
+        with closing(self._conn.cursor()) as cur:
+            row = cur.execute(
+                "SELECT volume FROM daily_volumes WHERE symbol = ? AND as_of = ?",
+                (symbol.upper(), as_of.isoformat()),
+            ).fetchone()
+        return int(row[0]) if row is not None else None
+
+    def avg_daily_volume(
+        self,
+        symbol: str,
+        end_inclusive: date,
+        lookback_days: int = 30,
+    ) -> Decimal | None:
+        if lookback_days <= 0:
+            msg = "lookback_days must be positive"
+            raise ValueError(msg)
+        with closing(self._conn.cursor()) as cur:
+            row = cur.execute(
+                """
+                SELECT AVG(volume), COUNT(*)
+                FROM (
+                    SELECT volume FROM daily_volumes
+                    WHERE symbol = ? AND as_of <= ?
+                    ORDER BY as_of DESC
+                    LIMIT ?
+                )
+                """,
+                (symbol.upper(), end_inclusive.isoformat(), lookback_days),
+            ).fetchone()
+        if row is None or row[1] == 0:
+            return None
+        return Decimal(str(row[0]))
+
+    def relative_volume(
+        self,
+        symbol: str,
+        as_of: date,
+        today_volume: int,
+        lookback_days: int = 30,
+    ) -> Decimal | None:
+        # Average over the trailing window *before* today.
+        prior_day = date.fromordinal(as_of.toordinal() - 1)
+        avg = self.avg_daily_volume(symbol, prior_day, lookback_days)
+        if avg is None or avg == 0:
+            return None
+        return Decimal(today_volume) / avg
+
+    def record_ema(self, symbol: str, as_of: date, period: int, value: Decimal) -> None:
+        with closing(self._conn.cursor()) as cur:
+            cur.execute(
+                """
+                INSERT OR REPLACE INTO daily_emas(symbol, as_of, period, value)
+                VALUES (?, ?, ?, ?)
+                """,
+                (symbol.upper(), as_of.isoformat(), int(period), str(value)),
+            )
+        self._conn.commit()
+
+    def record_emas(
+        self,
+        rows: Iterable[tuple[str, date, int, Decimal]],
+    ) -> None:
+        materialized = [
+            (s.upper(), d.isoformat(), int(p), str(v)) for s, d, p, v in rows
+        ]
+        if not materialized:
+            return
+        with closing(self._conn.cursor()) as cur:
+            cur.executemany(
+                """
+                INSERT OR REPLACE INTO daily_emas(symbol, as_of, period, value)
+                VALUES (?, ?, ?, ?)
+                """,
+                materialized,
+            )
+        self._conn.commit()
+
+    def ema(self, symbol: str, as_of: date, period: int) -> Decimal | None:
+        with closing(self._conn.cursor()) as cur:
+            row = cur.execute(
+                "SELECT value FROM daily_emas WHERE symbol = ? AND as_of = ? AND period = ?",
+                (symbol.upper(), as_of.isoformat(), int(period)),
+            ).fetchone()
+        return Decimal(row[0]) if row is not None else None

--- a/src/ross_trading/data/float_reference.py
+++ b/src/ross_trading/data/float_reference.py
@@ -1,0 +1,73 @@
+"""Float-reference provider interface and daily-cache wrapper.
+
+Phase 1 issue #2 requires the *cache layer* to be vendor-agnostic.
+The concrete vendor implementation is blocked on decision issue #33.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from ross_trading.core.clock import Clock, RealClock
+
+if TYPE_CHECKING:
+    from ross_trading.data.types import FloatRecord
+
+DEFAULT_CACHE_TTL = timedelta(hours=24)
+
+
+@runtime_checkable
+class FloatReferenceProvider(Protocol):
+    """Daily float lookups for a ticker."""
+
+    async def get_float(self, ticker: str, as_of: date) -> FloatRecord: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _Entry:
+    record: FloatRecord
+    fetched_at: datetime
+
+
+class CachedFloatReference:
+    """24-hour in-memory cache in front of any :class:`FloatReferenceProvider`.
+
+    The cache is *opt-in invalidated* via :meth:`invalidate` — risk
+    issue #23 (same-day dilution detection) is the home for the
+    decision logic that fires the invalidation; this layer just
+    exposes the hook.
+    """
+
+    def __init__(
+        self,
+        upstream: FloatReferenceProvider,
+        clock: Clock | None = None,
+        ttl: timedelta = DEFAULT_CACHE_TTL,
+    ) -> None:
+        if ttl <= timedelta(0):
+            msg = "cache ttl must be positive"
+            raise ValueError(msg)
+        self._upstream = upstream
+        self._clock: Clock = clock if clock is not None else RealClock()
+        self._ttl = ttl
+        self._cache: dict[tuple[str, date], _Entry] = {}
+
+    async def get_float(self, ticker: str, as_of: date) -> FloatRecord:
+        key = (ticker.upper(), as_of)
+        now = self._clock.now()
+        cached = self._cache.get(key)
+        if cached is not None and now - cached.fetched_at < self._ttl:
+            return cached.record
+        record = await self._upstream.get_float(ticker, as_of)
+        self._cache[key] = _Entry(record=record, fetched_at=now)
+        return record
+
+    def invalidate(self, ticker: str) -> int:
+        """Drop every cached entry for ``ticker``. Returns count dropped."""
+        upper = ticker.upper()
+        keys = [k for k in self._cache if k[0] == upper]
+        for k in keys:
+            del self._cache[k]
+        return len(keys)

--- a/src/ross_trading/data/historical.py
+++ b/src/ross_trading/data/historical.py
@@ -1,0 +1,85 @@
+"""Historical computations: 30-day relative volume, daily-EMA precompute.
+
+These functions read daily bars from any :class:`MarketDataProvider`
+(including the replay provider) and persist derived values into a
+shared :class:`HistoricalCache`. Architecture §3.1 (rel-vol filter)
+and §3.3 (EMA20/50/200 daily-strength filter) consume what this
+module produces.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
+from typing import TYPE_CHECKING
+
+from ross_trading.data.market_feed import MarketDataProvider, Timeframe
+from ross_trading.indicators.ema import ema_series
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from decimal import Decimal
+
+    from ross_trading.data.cache import HistoricalCache
+    from ross_trading.data.types import Bar
+
+DEFAULT_VOLUME_LOOKBACK = 30
+DEFAULT_EMA_PERIODS: tuple[int, ...] = (20, 50, 200)
+
+
+async def populate_daily_volumes(
+    provider: MarketDataProvider,
+    symbol: str,
+    end_inclusive: date,
+    cache: HistoricalCache,
+    lookback_days: int = DEFAULT_VOLUME_LOOKBACK,
+) -> int:
+    """Fetch daily bars for the trailing window and write volumes to cache.
+
+    Returns the number of rows written.
+    """
+    bars = await _fetch_daily_bars(provider, symbol, end_inclusive, lookback_days + 5)
+    cache.record_daily_volumes((b.symbol, b.ts.date(), b.volume) for b in bars)
+    return len(bars)
+
+
+async def precompute_daily_emas(
+    provider: MarketDataProvider,
+    symbol: str,
+    end_inclusive: date,
+    cache: HistoricalCache,
+    periods: Iterable[int] = DEFAULT_EMA_PERIODS,
+    history_days: int = 250,
+) -> int:
+    """Compute and persist EMA(period) for each day in the supplied window.
+
+    ``history_days`` should be at least the longest period plus a small
+    margin so the EMA has stabilised by the dates the scanner queries.
+    Returns the number of (symbol, day, period) rows written.
+    """
+    periods_list = list(periods)
+    bars = await _fetch_daily_bars(provider, symbol, end_inclusive, history_days)
+    if not bars:
+        return 0
+    closes = [b.close for b in bars]
+    rows: list[tuple[str, date, int, Decimal]] = []
+    for period in periods_list:
+        emas = ema_series(closes, period)
+        for bar, value in zip(bars, emas, strict=True):
+            rows.append((symbol.upper(), bar.ts.date(), period, value))
+    cache.record_emas(rows)
+    return len(rows)
+
+
+async def _fetch_daily_bars(
+    provider: MarketDataProvider,
+    symbol: str,
+    end_inclusive: date,
+    days: int,
+) -> Sequence[Bar]:
+    end_dt = datetime.combine(end_inclusive + timedelta(days=1), time.min, tzinfo=UTC)
+    start_dt = datetime.combine(
+        end_inclusive - timedelta(days=days),
+        time.min,
+        tzinfo=UTC,
+    )
+    return await provider.historical_bars(symbol, start_dt, end_dt, Timeframe.D1)

--- a/src/ross_trading/data/market_feed.py
+++ b/src/ross_trading/data/market_feed.py
@@ -1,0 +1,62 @@
+"""Market data provider interface.
+
+Concrete vendor implementations live under ``data/providers/``.
+Anything that streams quotes, bars, or tape prints — including
+recordings replayed from disk — implements :class:`MarketDataProvider`.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+    from datetime import datetime
+
+    from ross_trading.data.types import Bar, Quote, Tape
+
+
+class Timeframe(StrEnum):
+    """Bar aggregation periods.
+
+    Not every provider supports every timeframe (10-second bars are
+    a known gap — see decision issue #14). Providers should expose
+    ``supported_timeframes`` so callers can fail fast.
+    """
+
+    S1 = "S1"
+    S10 = "S10"
+    M1 = "M1"
+    M5 = "M5"
+    D1 = "D1"
+
+
+@runtime_checkable
+class MarketDataProvider(Protocol):
+    """Streaming + historical access to NBBO quotes, bars, and tape prints."""
+
+    @property
+    def supported_timeframes(self) -> frozenset[Timeframe]: ...
+
+    async def connect(self) -> None: ...
+
+    async def disconnect(self) -> None: ...
+
+    def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]: ...
+
+    def subscribe_bars(
+        self,
+        symbols: Iterable[str],
+        timeframe: Timeframe,
+    ) -> AsyncIterator[Bar]: ...
+
+    def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]: ...
+
+    async def historical_bars(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        timeframe: Timeframe,
+    ) -> Sequence[Bar]: ...

--- a/src/ross_trading/data/market_feed.py
+++ b/src/ross_trading/data/market_feed.py
@@ -3,12 +3,22 @@
 Concrete vendor implementations live under ``data/providers/``.
 Anything that streams quotes, bars, or tape prints — including
 recordings replayed from disk — implements :class:`MarketDataProvider`.
+
+Note on protocol shape: ``subscribe_*`` methods are declared as plain
+``def`` returning :class:`AsyncIterator`. Implementations are
+typically async generator functions (``async def`` with ``yield``);
+this is intentional — calling ``provider.subscribe_quotes(...)``
+returns an iterator directly without needing ``await``, which is the
+canonical pattern for streaming sources in Python (PEP 525).
+``inspect.iscoroutinefunction`` will return ``False`` for these
+methods; ``inspect.isasyncgenfunction`` will return ``True``.
 """
 
 from __future__ import annotations
 
-from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from ross_trading.data.types import Timeframe
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Sequence
@@ -17,19 +27,7 @@ if TYPE_CHECKING:
     from ross_trading.data.types import Bar, Quote, Tape
 
 
-class Timeframe(StrEnum):
-    """Bar aggregation periods.
-
-    Not every provider supports every timeframe (10-second bars are
-    a known gap — see decision issue #14). Providers should expose
-    ``supported_timeframes`` so callers can fail fast.
-    """
-
-    S1 = "S1"
-    S10 = "S10"
-    M1 = "M1"
-    M5 = "M5"
-    D1 = "D1"
+__all__ = ["MarketDataProvider", "Timeframe"]
 
 
 @runtime_checkable

--- a/src/ross_trading/data/news_feed.py
+++ b/src/ross_trading/data/news_feed.py
@@ -1,0 +1,91 @@
+"""News provider interface and headline deduplication.
+
+The dedup window is sliding and clock-driven so replay is
+deterministic — see :class:`HeadlineDeduper`.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from ross_trading.core.clock import Clock, RealClock
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+
+    from ross_trading.data.types import Headline
+
+DEFAULT_DEDUP_WINDOW = timedelta(hours=24)
+
+
+@runtime_checkable
+class NewsProvider(Protocol):
+    """Streaming + historical headline access."""
+
+    async def connect(self) -> None: ...
+
+    async def disconnect(self) -> None: ...
+
+    def subscribe_headlines(
+        self,
+        symbols: Iterable[str] | None = None,
+    ) -> AsyncIterator[Headline]: ...
+
+    async def recent_headlines(
+        self,
+        symbol: str,
+        since: datetime,
+    ) -> Sequence[Headline]: ...
+
+
+class HeadlineDeduper:
+    """Sliding-window deduper keyed on ``(source, normalized_title, ticker)``.
+
+    Independent of wall-clock time: callers must provide a :class:`Clock`
+    so replay produces the same dedup decisions as the live run.
+    """
+
+    def __init__(
+        self,
+        window: timedelta = DEFAULT_DEDUP_WINDOW,
+        clock: Clock | None = None,
+        max_entries: int = 100_000,
+    ) -> None:
+        if window <= timedelta(0):
+            msg = "dedup window must be positive"
+            raise ValueError(msg)
+        if max_entries <= 0:
+            msg = "max_entries must be positive"
+            raise ValueError(msg)
+        self._window = window
+        self._clock: Clock = clock if clock is not None else RealClock()
+        self._max_entries = max_entries
+        self._seen: OrderedDict[tuple[str, str, str], datetime] = OrderedDict()
+
+    def is_duplicate(self, headline: Headline) -> bool:
+        """Return True if a matching headline was seen within the window.
+
+        Calling this *records* the headline as seen — call once per
+        incoming headline.
+        """
+        self._evict_expired()
+        key = headline.dedup_key
+        if key in self._seen:
+            self._seen.move_to_end(key)
+            self._seen[key] = headline.ts
+            return True
+        self._seen[key] = headline.ts
+        if len(self._seen) > self._max_entries:
+            self._seen.popitem(last=False)
+        return False
+
+    def _evict_expired(self) -> None:
+        cutoff = self._clock.now() - self._window
+        while self._seen:
+            oldest_key = next(iter(self._seen))
+            if self._seen[oldest_key] < cutoff:
+                self._seen.pop(oldest_key)
+            else:
+                break

--- a/src/ross_trading/data/news_feed.py
+++ b/src/ross_trading/data/news_feed.py
@@ -1,7 +1,10 @@
 """News provider interface and headline deduplication.
 
-The dedup window is sliding and clock-driven so replay is
-deterministic — see :class:`HeadlineDeduper`.
+The dedup window slides against the *event-time* of incoming
+headlines (``Headline.ts``), not wall-clock time. This is what makes
+replay deterministic — under fast-replay where no virtual time
+advances, expiry still works because the headline timestamps
+themselves carry the recorded session's progression.
 """
 
 from __future__ import annotations
@@ -9,8 +12,6 @@ from __future__ import annotations
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
-
-from ross_trading.core.clock import Clock, RealClock
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Sequence
@@ -43,14 +44,14 @@ class NewsProvider(Protocol):
 class HeadlineDeduper:
     """Sliding-window deduper keyed on ``(source, normalized_title, ticker)``.
 
-    Independent of wall-clock time: callers must provide a :class:`Clock`
-    so replay produces the same dedup decisions as the live run.
+    Eviction compares ``headline.ts - window`` against stored
+    timestamps, so the deduper produces the same decisions live and
+    in fast-replay regardless of how the clock advances.
     """
 
     def __init__(
         self,
         window: timedelta = DEFAULT_DEDUP_WINDOW,
-        clock: Clock | None = None,
         max_entries: int = 100_000,
     ) -> None:
         if window <= timedelta(0):
@@ -60,7 +61,6 @@ class HeadlineDeduper:
             msg = "max_entries must be positive"
             raise ValueError(msg)
         self._window = window
-        self._clock: Clock = clock if clock is not None else RealClock()
         self._max_entries = max_entries
         self._seen: OrderedDict[tuple[str, str, str], datetime] = OrderedDict()
 
@@ -70,7 +70,7 @@ class HeadlineDeduper:
         Calling this *records* the headline as seen — call once per
         incoming headline.
         """
-        self._evict_expired()
+        self._evict_expired_against(headline.ts)
         key = headline.dedup_key
         if key in self._seen:
             self._seen.move_to_end(key)
@@ -81,8 +81,8 @@ class HeadlineDeduper:
             self._seen.popitem(last=False)
         return False
 
-    def _evict_expired(self) -> None:
-        cutoff = self._clock.now() - self._window
+    def _evict_expired_against(self, now: datetime) -> None:
+        cutoff = now - self._window
         while self._seen:
             oldest_key = next(iter(self._seen))
             if self._seen[oldest_key] < cutoff:

--- a/src/ross_trading/data/providers/__init__.py
+++ b/src/ross_trading/data/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete data providers (replay, fakes, vendor implementations)."""

--- a/src/ross_trading/data/providers/replay.py
+++ b/src/ross_trading/data/providers/replay.py
@@ -205,7 +205,9 @@ class ReplayProvider:
             if date_from is not None and day < date_from:
                 continue
             if date_to is not None and day > date_to:
-                continue
+                # Directories are iterated in sorted ascending order, so
+                # every remaining entry will also exceed date_to.
+                break
             path = day_dir / f"{event_type.value}.jsonl.gz"
             if not path.exists():
                 continue

--- a/src/ross_trading/data/providers/replay.py
+++ b/src/ross_trading/data/providers/replay.py
@@ -1,0 +1,231 @@
+"""Replay provider — reads recordings from disk and emits them.
+
+Two timing modes:
+
+* :attr:`ReplayMode.AS_FAST_AS_POSSIBLE` — for tests and backfills,
+  events are yielded immediately in timestamp order.
+* :attr:`ReplayMode.REALTIME` — events are paced to honor the
+  original inter-arrival times against the supplied clock.
+
+Pacing is per-subscription: the first event of each stream anchors
+that stream's wall-clock baseline. All streams started under the
+same provider session will therefore stay coherent with each other
+within one wall-clock anchor.
+"""
+
+from __future__ import annotations
+
+import gzip
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from ross_trading.core.clock import Clock, RealClock
+from ross_trading.core.errors import MissingRecordingError
+from ross_trading.data._codec import (
+    EventType,
+    decode_bar,
+    decode_envelope,
+    decode_float,
+    decode_headline,
+    decode_quote,
+    decode_tape,
+)
+from ross_trading.data.market_feed import Timeframe
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+    from datetime import date, datetime
+    from pathlib import Path
+
+    from ross_trading.data.types import Bar, FloatRecord, Headline, Quote, Tape
+
+
+class ReplayMode(StrEnum):
+    AS_FAST_AS_POSSIBLE = "fast"
+    REALTIME = "realtime"
+
+
+class ReplayProvider:
+    """Implements :class:`MarketDataProvider`, :class:`NewsProvider`, and
+    :class:`FloatReferenceProvider` from a recordings directory."""
+
+    def __init__(
+        self,
+        recordings_dir: Path,
+        mode: ReplayMode = ReplayMode.AS_FAST_AS_POSSIBLE,
+        clock: Clock | None = None,
+        timeframes: Iterable[Timeframe] = (
+            Timeframe.S1,
+            Timeframe.M1,
+            Timeframe.M5,
+            Timeframe.D1,
+        ),
+    ) -> None:
+        self._dir = recordings_dir
+        self._mode = mode
+        self._clock: Clock = clock if clock is not None else RealClock()
+        self._timeframes = frozenset(timeframes)
+        self._float_records: dict[tuple[str, date], FloatRecord] = {}
+        self._connected = False
+
+    @property
+    def supported_timeframes(self) -> frozenset[Timeframe]:
+        return self._timeframes
+
+    async def connect(self) -> None:
+        self._load_float_records()
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        self._connected = False
+
+    async def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]:
+        wanted = {s.upper() for s in symbols}
+        anchor = _Anchor()
+        for line in self._read_lines(EventType.QUOTE):
+            event_type, payload = decode_envelope(line)
+            if event_type != EventType.QUOTE:
+                continue
+            quote = decode_quote(payload)
+            if quote.symbol.upper() not in wanted:
+                continue
+            await self._maybe_pace(quote.ts, anchor)
+            yield quote
+
+    async def subscribe_bars(
+        self,
+        symbols: Iterable[str],
+        timeframe: Timeframe,
+    ) -> AsyncIterator[Bar]:
+        wanted = {s.upper() for s in symbols}
+        anchor = _Anchor()
+        for line in self._read_lines(EventType.BAR):
+            event_type, payload = decode_envelope(line)
+            if event_type != EventType.BAR:
+                continue
+            bar = decode_bar(payload)
+            if bar.symbol.upper() not in wanted or bar.timeframe != timeframe.value:
+                continue
+            await self._maybe_pace(bar.ts, anchor)
+            yield bar
+
+    async def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]:
+        wanted = {s.upper() for s in symbols}
+        anchor = _Anchor()
+        for line in self._read_lines(EventType.TAPE):
+            event_type, payload = decode_envelope(line)
+            if event_type != EventType.TAPE:
+                continue
+            tape = decode_tape(payload)
+            if tape.symbol.upper() not in wanted:
+                continue
+            await self._maybe_pace(tape.ts, anchor)
+            yield tape
+
+    async def historical_bars(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        timeframe: Timeframe,
+    ) -> Sequence[Bar]:
+        upper = symbol.upper()
+        result: list[Bar] = []
+        for line in self._read_lines(EventType.BAR):
+            event_type, payload = decode_envelope(line)
+            if event_type != EventType.BAR:
+                continue
+            bar = decode_bar(payload)
+            if (
+                bar.symbol.upper() == upper
+                and bar.timeframe == timeframe.value
+                and start <= bar.ts < end
+            ):
+                result.append(bar)
+        return result
+
+    async def subscribe_headlines(
+        self,
+        symbols: Iterable[str] | None = None,
+    ) -> AsyncIterator[Headline]:
+        wanted = None if symbols is None else {s.upper() for s in symbols}
+        anchor = _Anchor()
+        for line in self._read_lines(EventType.HEADLINE):
+            event_type, payload = decode_envelope(line)
+            if event_type != EventType.HEADLINE:
+                continue
+            headline = decode_headline(payload)
+            if wanted is not None and headline.ticker.upper() not in wanted:
+                continue
+            await self._maybe_pace(headline.ts, anchor)
+            yield headline
+
+    async def recent_headlines(
+        self,
+        symbol: str,
+        since: datetime,
+    ) -> Sequence[Headline]:
+        upper = symbol.upper()
+        result: list[Headline] = []
+        for line in self._read_lines(EventType.HEADLINE):
+            event_type, payload = decode_envelope(line)
+            if event_type != EventType.HEADLINE:
+                continue
+            headline = decode_headline(payload)
+            if headline.ticker.upper() == upper and headline.ts >= since:
+                result.append(headline)
+        return result
+
+    async def get_float(self, ticker: str, as_of: date) -> FloatRecord:
+        if not self._float_records:
+            self._load_float_records()
+        key = (ticker.upper(), as_of)
+        rec = self._float_records.get(key)
+        if rec is None:
+            msg = f"no recorded float for {ticker} on {as_of}"
+            raise MissingRecordingError(msg)
+        return rec
+
+    def _load_float_records(self) -> None:
+        for line in self._read_lines(EventType.FLOAT):
+            event_type, payload = decode_envelope(line)
+            if event_type != EventType.FLOAT:
+                continue
+            rec = decode_float(payload)
+            self._float_records[(rec.ticker.upper(), rec.as_of)] = rec
+
+    def _read_lines(self, event_type: EventType) -> Iterable[str]:
+        if not self._dir.exists():
+            return
+        for day_dir in sorted(p for p in self._dir.iterdir() if p.is_dir()):
+            path = day_dir / f"{event_type.value}.jsonl.gz"
+            if not path.exists():
+                continue
+            with gzip.open(path, "rt", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        yield line
+
+    async def _maybe_pace(self, event_ts: datetime, anchor: _Anchor) -> None:
+        if self._mode is not ReplayMode.REALTIME:
+            return
+        if anchor.event_ts is None:
+            anchor.event_ts = event_ts
+            anchor.monotonic_at_anchor = self._clock.monotonic()
+            return
+        target_elapsed = (event_ts - anchor.event_ts).total_seconds()
+        actual_elapsed = self._clock.monotonic() - anchor.monotonic_at_anchor
+        delay = target_elapsed - actual_elapsed
+        if delay > 0:
+            await self._clock.sleep(delay)
+
+
+class _Anchor:
+    """Per-subscription pacing anchor."""
+
+    __slots__ = ("event_ts", "monotonic_at_anchor")
+
+    def __init__(self) -> None:
+        self.event_ts: datetime | None = None
+        self.monotonic_at_anchor: float = 0.0

--- a/src/ross_trading/data/providers/replay.py
+++ b/src/ross_trading/data/providers/replay.py
@@ -11,11 +11,16 @@ Pacing is per-subscription: the first event of each stream anchors
 that stream's wall-clock baseline. All streams started under the
 same provider session will therefore stay coherent with each other
 within one wall-clock anchor.
+
+``_read_lines`` accepts an optional date range so callers like
+:meth:`historical_bars` only open the files for the days they care
+about, avoiding a full archive scan per query.
 """
 
 from __future__ import annotations
 
 import gzip
+from datetime import date as _date_type
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -30,7 +35,7 @@ from ross_trading.data._codec import (
     decode_quote,
     decode_tape,
 )
-from ross_trading.data.market_feed import Timeframe
+from ross_trading.data.types import Timeframe
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Sequence
@@ -83,9 +88,7 @@ class ReplayProvider:
         wanted = {s.upper() for s in symbols}
         anchor = _Anchor()
         for line in self._read_lines(EventType.QUOTE):
-            event_type, payload = decode_envelope(line)
-            if event_type != EventType.QUOTE:
-                continue
+            _, payload = decode_envelope(line)
             quote = decode_quote(payload)
             if quote.symbol.upper() not in wanted:
                 continue
@@ -100,9 +103,7 @@ class ReplayProvider:
         wanted = {s.upper() for s in symbols}
         anchor = _Anchor()
         for line in self._read_lines(EventType.BAR):
-            event_type, payload = decode_envelope(line)
-            if event_type != EventType.BAR:
-                continue
+            _, payload = decode_envelope(line)
             bar = decode_bar(payload)
             if bar.symbol.upper() not in wanted or bar.timeframe != timeframe.value:
                 continue
@@ -113,9 +114,7 @@ class ReplayProvider:
         wanted = {s.upper() for s in symbols}
         anchor = _Anchor()
         for line in self._read_lines(EventType.TAPE):
-            event_type, payload = decode_envelope(line)
-            if event_type != EventType.TAPE:
-                continue
+            _, payload = decode_envelope(line)
             tape = decode_tape(payload)
             if tape.symbol.upper() not in wanted:
                 continue
@@ -131,10 +130,10 @@ class ReplayProvider:
     ) -> Sequence[Bar]:
         upper = symbol.upper()
         result: list[Bar] = []
-        for line in self._read_lines(EventType.BAR):
-            event_type, payload = decode_envelope(line)
-            if event_type != EventType.BAR:
-                continue
+        for line in self._read_lines(
+            EventType.BAR, date_from=start.date(), date_to=end.date()
+        ):
+            _, payload = decode_envelope(line)
             bar = decode_bar(payload)
             if (
                 bar.symbol.upper() == upper
@@ -151,9 +150,7 @@ class ReplayProvider:
         wanted = None if symbols is None else {s.upper() for s in symbols}
         anchor = _Anchor()
         for line in self._read_lines(EventType.HEADLINE):
-            event_type, payload = decode_envelope(line)
-            if event_type != EventType.HEADLINE:
-                continue
+            _, payload = decode_envelope(line)
             headline = decode_headline(payload)
             if wanted is not None and headline.ticker.upper() not in wanted:
                 continue
@@ -167,10 +164,8 @@ class ReplayProvider:
     ) -> Sequence[Headline]:
         upper = symbol.upper()
         result: list[Headline] = []
-        for line in self._read_lines(EventType.HEADLINE):
-            event_type, payload = decode_envelope(line)
-            if event_type != EventType.HEADLINE:
-                continue
+        for line in self._read_lines(EventType.HEADLINE, date_from=since.date()):
+            _, payload = decode_envelope(line)
             headline = decode_headline(payload)
             if headline.ticker.upper() == upper and headline.ts >= since:
                 result.append(headline)
@@ -188,22 +183,35 @@ class ReplayProvider:
 
     def _load_float_records(self) -> None:
         for line in self._read_lines(EventType.FLOAT):
-            event_type, payload = decode_envelope(line)
-            if event_type != EventType.FLOAT:
-                continue
+            _, payload = decode_envelope(line)
             rec = decode_float(payload)
             self._float_records[(rec.ticker.upper(), rec.as_of)] = rec
 
-    def _read_lines(self, event_type: EventType) -> Iterable[str]:
+    def _read_lines(
+        self,
+        event_type: EventType,
+        *,
+        date_from: date | None = None,
+        date_to: date | None = None,
+    ) -> Iterable[str]:
         if not self._dir.exists():
             return
         for day_dir in sorted(p for p in self._dir.iterdir() if p.is_dir()):
+            try:
+                day = _date_type.fromisoformat(day_dir.name)
+            except ValueError:
+                # Non-date directory (e.g. a backup folder); skip silently.
+                continue
+            if date_from is not None and day < date_from:
+                continue
+            if date_to is not None and day > date_to:
+                continue
             path = day_dir / f"{event_type.value}.jsonl.gz"
             if not path.exists():
                 continue
             with gzip.open(path, "rt", encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
+                for raw in f:
+                    line = raw.strip()
                     if line:
                         yield line
 

--- a/src/ross_trading/data/reconnect.py
+++ b/src/ross_trading/data/reconnect.py
@@ -14,13 +14,18 @@ Quote and tape subscriptions don't backfill — historical retrieval
 of NBBO and individual prints is rarely available and rarely useful;
 the gap event is sufficient.
 
+If reconnection itself raises :class:`FeedDisconnected` (e.g. the
+vendor is still down after the backoff wait), it propagates out and
+terminates the subscription — ``max_retries`` only governs the live
+subscription's retry budget, not the connect-on-recovery step.
+
 Related: risk issue #21.
 """
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable, Iterable, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from ross_trading.core.clock import Clock, RealClock
 from ross_trading.core.errors import FeedDisconnected
@@ -29,9 +34,10 @@ from ross_trading.data.types import Bar, FeedGap, Quote, Tape
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from ross_trading.data.market_feed import Timeframe
+    from ross_trading.data.market_feed import MarketDataProvider, Timeframe
 
 GapCallback = Callable[[FeedGap], None]
+_T = TypeVar("_T", Quote, Tape)
 
 
 def _noop_on_gap(_: FeedGap) -> None:
@@ -47,7 +53,7 @@ class ReconnectingProvider:
 
     def __init__(
         self,
-        upstream: object,  # duck-typed MarketDataProvider
+        upstream: MarketDataProvider,
         *,
         on_gap: GapCallback | None = None,
         max_backoff: float = DEFAULT_MAX_BACKOFF,
@@ -65,69 +71,31 @@ class ReconnectingProvider:
 
     @property
     def supported_timeframes(self) -> frozenset[Timeframe]:
-        return self._upstream.supported_timeframes  # type: ignore[no-any-return,attr-defined]
+        return self._upstream.supported_timeframes
 
     async def connect(self) -> None:
-        await self._upstream.connect()  # type: ignore[attr-defined]
+        await self._upstream.connect()
 
     async def disconnect(self) -> None:
-        await self._upstream.disconnect()  # type: ignore[attr-defined]
+        await self._upstream.disconnect()
 
     async def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]:
         symbols_list = list(symbols)
-        last_ts: datetime | None = None
-        backoff = INITIAL_BACKOFF
-        retries = 0
-        while True:
-            try:
-                async for quote in self._upstream.subscribe_quotes(symbols_list):  # type: ignore[attr-defined]
-                    last_ts = quote.ts
-                    backoff = INITIAL_BACKOFF
-                    yield quote
-                return
-            except FeedDisconnected as exc:
-                if self._max_retries is not None and retries >= self._max_retries:
-                    raise
-                retries += 1
-                gap_start = last_ts or self._clock.now()
-                await self._reconnect(backoff)
-                backoff = min(backoff * 2, self._max_backoff)
-                self._on_gap(
-                    FeedGap(
-                        symbol=None,
-                        start=gap_start,
-                        end=self._clock.now(),
-                        reason=str(exc) or type(exc).__name__,
-                    )
-                )
+
+        def factory() -> AsyncIterator[Quote]:
+            return self._upstream.subscribe_quotes(symbols_list)
+
+        async for quote in self._stream_with_retry(factory, ts_of=lambda q: q.ts):
+            yield quote
 
     async def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]:
         symbols_list = list(symbols)
-        last_ts: datetime | None = None
-        backoff = INITIAL_BACKOFF
-        retries = 0
-        while True:
-            try:
-                async for tape in self._upstream.subscribe_tape(symbols_list):  # type: ignore[attr-defined]
-                    last_ts = tape.ts
-                    backoff = INITIAL_BACKOFF
-                    yield tape
-                return
-            except FeedDisconnected as exc:
-                if self._max_retries is not None and retries >= self._max_retries:
-                    raise
-                retries += 1
-                gap_start = last_ts or self._clock.now()
-                await self._reconnect(backoff)
-                backoff = min(backoff * 2, self._max_backoff)
-                self._on_gap(
-                    FeedGap(
-                        symbol=None,
-                        start=gap_start,
-                        end=self._clock.now(),
-                        reason=str(exc) or type(exc).__name__,
-                    )
-                )
+
+        def factory() -> AsyncIterator[Tape]:
+            return self._upstream.subscribe_tape(symbols_list)
+
+        async for tape in self._stream_with_retry(factory, ts_of=lambda t: t.ts):
+            yield tape
 
     async def subscribe_bars(
         self,
@@ -140,7 +108,7 @@ class ReconnectingProvider:
         retries = 0
         while True:
             try:
-                async for bar in self._upstream.subscribe_bars(symbols_list, timeframe):  # type: ignore[attr-defined]
+                async for bar in self._upstream.subscribe_bars(symbols_list, timeframe):
                     last_ts[bar.symbol] = bar.ts
                     backoff = INITIAL_BACKOFF
                     yield bar
@@ -153,7 +121,9 @@ class ReconnectingProvider:
                 backoff = min(backoff * 2, self._max_backoff)
                 gap_end = self._clock.now()
                 gap_start = min(last_ts.values()) if last_ts else gap_end
-                async for backfilled in self._backfill(symbols_list, last_ts, timeframe, gap_end):
+                async for backfilled in self._backfill(
+                    symbols_list, last_ts, timeframe, gap_end
+                ):
                     yield backfilled
                 self._on_gap(
                     FeedGap(
@@ -171,16 +141,48 @@ class ReconnectingProvider:
         end: datetime,
         timeframe: Timeframe,
     ) -> Sequence[Bar]:
-        return await self._upstream.historical_bars(symbol, start, end, timeframe)  # type: ignore[attr-defined,no-any-return]
+        return await self._upstream.historical_bars(symbol, start, end, timeframe)
+
+    async def _stream_with_retry(
+        self,
+        factory: Callable[[], AsyncIterator[_T]],
+        ts_of: Callable[[_T], datetime],
+    ) -> AsyncIterator[_T]:
+        """Shared retry/gap-callback loop for non-backfilling streams."""
+        last_ts: datetime | None = None
+        backoff = INITIAL_BACKOFF
+        retries = 0
+        while True:
+            try:
+                async for event in factory():
+                    last_ts = ts_of(event)
+                    backoff = INITIAL_BACKOFF
+                    yield event
+                return
+            except FeedDisconnected as exc:
+                if self._max_retries is not None and retries >= self._max_retries:
+                    raise
+                retries += 1
+                gap_start = last_ts or self._clock.now()
+                await self._reconnect(backoff)
+                backoff = min(backoff * 2, self._max_backoff)
+                self._on_gap(
+                    FeedGap(
+                        symbol=None,
+                        start=gap_start,
+                        end=self._clock.now(),
+                        reason=str(exc) or type(exc).__name__,
+                    )
+                )
 
     async def _reconnect(self, backoff: float) -> None:
         await self._clock.sleep(backoff)
-        try:
-            await self._upstream.connect()  # type: ignore[attr-defined]
-        except FeedDisconnected:
-            # Caller's outer loop will retry — propagate to next iteration
-            # by re-raising so the surrounding try/except picks it up.
-            raise
+        # If connect() itself raises FeedDisconnected, the exception
+        # propagates out of the active `except FeedDisconnected` block
+        # in the caller, ending the retry loop. Vendor implementations
+        # that want extended retry of connect() should layer their own
+        # backoff inside connect(), not rely on this wrapper.
+        await self._upstream.connect()
 
     async def _backfill(
         self,
@@ -193,10 +195,9 @@ class ReconnectingProvider:
             anchor = last_ts.get(symbol)
             if anchor is None:
                 continue
-            bars = await self._upstream.historical_bars(  # type: ignore[attr-defined]
-                symbol, anchor, gap_end, timeframe
-            )
+            bars = await self._upstream.historical_bars(symbol, anchor, gap_end, timeframe)
             for bar in bars:
                 if bar.ts > anchor:
                     last_ts[symbol] = bar.ts
                     yield bar
+

--- a/src/ross_trading/data/reconnect.py
+++ b/src/ross_trading/data/reconnect.py
@@ -1,0 +1,202 @@
+"""Reconnect / backfill wrapper for :class:`MarketDataProvider`.
+
+If an upstream subscription raises :class:`FeedDisconnected`, this
+wrapper:
+
+1. sleeps with exponential backoff (capped at ``max_backoff``);
+2. calls ``upstream.connect()`` and ``subscribe_*`` again;
+3. for **bar** subscriptions, calls ``historical_bars`` to backfill
+   the gap window before resuming the live stream;
+4. fires the ``on_gap`` callback with a :class:`FeedGap` event so
+   the journal (or a regression test) can record what was missed.
+
+Quote and tape subscriptions don't backfill — historical retrieval
+of NBBO and individual prints is rarely available and rarely useful;
+the gap event is sufficient.
+
+Related: risk issue #21.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Iterable, Sequence
+from typing import TYPE_CHECKING
+
+from ross_trading.core.clock import Clock, RealClock
+from ross_trading.core.errors import FeedDisconnected
+from ross_trading.data.types import Bar, FeedGap, Quote, Tape
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from ross_trading.data.market_feed import Timeframe
+
+GapCallback = Callable[[FeedGap], None]
+
+
+def _noop_on_gap(_: FeedGap) -> None:
+    return
+
+
+INITIAL_BACKOFF = 1.0
+DEFAULT_MAX_BACKOFF = 30.0
+
+
+class ReconnectingProvider:
+    """Wrap an upstream :class:`MarketDataProvider` with retry + backfill."""
+
+    def __init__(
+        self,
+        upstream: object,  # duck-typed MarketDataProvider
+        *,
+        on_gap: GapCallback | None = None,
+        max_backoff: float = DEFAULT_MAX_BACKOFF,
+        max_retries: int | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        if max_backoff <= 0:
+            msg = "max_backoff must be positive"
+            raise ValueError(msg)
+        self._upstream = upstream
+        self._on_gap: GapCallback = on_gap if on_gap is not None else _noop_on_gap
+        self._max_backoff = max_backoff
+        self._max_retries = max_retries
+        self._clock: Clock = clock if clock is not None else RealClock()
+
+    @property
+    def supported_timeframes(self) -> frozenset[Timeframe]:
+        return self._upstream.supported_timeframes  # type: ignore[no-any-return,attr-defined]
+
+    async def connect(self) -> None:
+        await self._upstream.connect()  # type: ignore[attr-defined]
+
+    async def disconnect(self) -> None:
+        await self._upstream.disconnect()  # type: ignore[attr-defined]
+
+    async def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]:
+        symbols_list = list(symbols)
+        last_ts: datetime | None = None
+        backoff = INITIAL_BACKOFF
+        retries = 0
+        while True:
+            try:
+                async for quote in self._upstream.subscribe_quotes(symbols_list):  # type: ignore[attr-defined]
+                    last_ts = quote.ts
+                    backoff = INITIAL_BACKOFF
+                    yield quote
+                return
+            except FeedDisconnected as exc:
+                if self._max_retries is not None and retries >= self._max_retries:
+                    raise
+                retries += 1
+                gap_start = last_ts or self._clock.now()
+                await self._reconnect(backoff)
+                backoff = min(backoff * 2, self._max_backoff)
+                self._on_gap(
+                    FeedGap(
+                        symbol=None,
+                        start=gap_start,
+                        end=self._clock.now(),
+                        reason=str(exc) or type(exc).__name__,
+                    )
+                )
+
+    async def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]:
+        symbols_list = list(symbols)
+        last_ts: datetime | None = None
+        backoff = INITIAL_BACKOFF
+        retries = 0
+        while True:
+            try:
+                async for tape in self._upstream.subscribe_tape(symbols_list):  # type: ignore[attr-defined]
+                    last_ts = tape.ts
+                    backoff = INITIAL_BACKOFF
+                    yield tape
+                return
+            except FeedDisconnected as exc:
+                if self._max_retries is not None and retries >= self._max_retries:
+                    raise
+                retries += 1
+                gap_start = last_ts or self._clock.now()
+                await self._reconnect(backoff)
+                backoff = min(backoff * 2, self._max_backoff)
+                self._on_gap(
+                    FeedGap(
+                        symbol=None,
+                        start=gap_start,
+                        end=self._clock.now(),
+                        reason=str(exc) or type(exc).__name__,
+                    )
+                )
+
+    async def subscribe_bars(
+        self,
+        symbols: Iterable[str],
+        timeframe: Timeframe,
+    ) -> AsyncIterator[Bar]:
+        symbols_list = list(symbols)
+        last_ts: dict[str, datetime] = {}
+        backoff = INITIAL_BACKOFF
+        retries = 0
+        while True:
+            try:
+                async for bar in self._upstream.subscribe_bars(symbols_list, timeframe):  # type: ignore[attr-defined]
+                    last_ts[bar.symbol] = bar.ts
+                    backoff = INITIAL_BACKOFF
+                    yield bar
+                return
+            except FeedDisconnected as exc:
+                if self._max_retries is not None and retries >= self._max_retries:
+                    raise
+                retries += 1
+                await self._reconnect(backoff)
+                backoff = min(backoff * 2, self._max_backoff)
+                gap_end = self._clock.now()
+                gap_start = min(last_ts.values()) if last_ts else gap_end
+                async for backfilled in self._backfill(symbols_list, last_ts, timeframe, gap_end):
+                    yield backfilled
+                self._on_gap(
+                    FeedGap(
+                        symbol=None,
+                        start=gap_start,
+                        end=gap_end,
+                        reason=str(exc) or type(exc).__name__,
+                    )
+                )
+
+    async def historical_bars(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        timeframe: Timeframe,
+    ) -> Sequence[Bar]:
+        return await self._upstream.historical_bars(symbol, start, end, timeframe)  # type: ignore[attr-defined,no-any-return]
+
+    async def _reconnect(self, backoff: float) -> None:
+        await self._clock.sleep(backoff)
+        try:
+            await self._upstream.connect()  # type: ignore[attr-defined]
+        except FeedDisconnected:
+            # Caller's outer loop will retry — propagate to next iteration
+            # by re-raising so the surrounding try/except picks it up.
+            raise
+
+    async def _backfill(
+        self,
+        symbols: Iterable[str],
+        last_ts: dict[str, datetime],
+        timeframe: Timeframe,
+        gap_end: datetime,
+    ) -> AsyncIterator[Bar]:
+        for symbol in symbols:
+            anchor = last_ts.get(symbol)
+            if anchor is None:
+                continue
+            bars = await self._upstream.historical_bars(  # type: ignore[attr-defined]
+                symbol, anchor, gap_end, timeframe
+            )
+            for bar in bars:
+                if bar.ts > anchor:
+                    last_ts[symbol] = bar.ts
+                    yield bar

--- a/src/ross_trading/data/recorder.py
+++ b/src/ross_trading/data/recorder.py
@@ -1,0 +1,106 @@
+"""Multi-stream feed recorder.
+
+Each event class gets its own gzip-compressed JSON-Lines file under
+``<output_dir>/<UTC-date>/<type>.jsonl.gz``. The recorder is the
+producer side; the replay provider is the consumer.
+
+Example::
+
+    async with FeedRecorder(Path("./recordings")) as rec:
+        async for q in provider.subscribe_quotes(["AVTX"]):
+            rec.record_quote(q)
+
+The recorder is *best-effort*: an unflushed crash may lose the tail
+of the current gzip block. Call :meth:`flush` periodically if that
+matters; :meth:`close` always flushes.
+"""
+
+from __future__ import annotations
+
+import gzip
+from typing import IO, TYPE_CHECKING, Self
+
+from ross_trading.core.clock import Clock, RealClock
+from ross_trading.data._codec import (
+    EventType,
+    encode_bar,
+    encode_event,
+    encode_float,
+    encode_headline,
+    encode_quote,
+    encode_tape,
+)
+
+if TYPE_CHECKING:
+    from datetime import date
+    from pathlib import Path
+    from types import TracebackType
+
+    from ross_trading.data.types import Bar, FloatRecord, Headline, Quote, Tape
+
+
+class FeedRecorder:
+    """Append-only writer with one file per (UTC-date, event-type)."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        clock: Clock | None = None,
+    ) -> None:
+        self._output_dir = output_dir
+        self._clock: Clock = clock if clock is not None else RealClock()
+        self._files: dict[tuple[str, EventType], IO[str]] = {}
+        self._closed = False
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    def record_quote(self, q: Quote) -> None:
+        self._write(EventType.QUOTE, q.ts.date(), encode_quote(q))
+
+    def record_bar(self, b: Bar) -> None:
+        self._write(EventType.BAR, b.ts.date(), encode_bar(b))
+
+    def record_tape(self, t: Tape) -> None:
+        self._write(EventType.TAPE, t.ts.date(), encode_tape(t))
+
+    def record_headline(self, h: Headline) -> None:
+        self._write(EventType.HEADLINE, h.ts.date(), encode_headline(h))
+
+    def record_float(self, r: FloatRecord) -> None:
+        self._write(EventType.FLOAT, r.as_of, encode_float(r))
+
+    def flush(self) -> None:
+        for f in self._files.values():
+            f.flush()
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for f in self._files.values():
+            f.close()
+        self._files.clear()
+
+    def _write(self, event_type: EventType, day: date, payload: dict[str, object]) -> None:
+        if self._closed:
+            msg = "recorder is closed"
+            raise RuntimeError(msg)
+        key = (day.isoformat(), event_type)
+        handle = self._files.get(key)
+        if handle is None:
+            path = self._output_dir / day.isoformat() / f"{event_type.value}.jsonl.gz"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            handle = gzip.open(path, "at", encoding="utf-8")  # noqa: SIM115  (closed in self.close())
+            self._files[key] = handle
+        line = encode_event(event_type, payload, self._clock.now())
+        handle.write(line)
+        handle.write("\n")

--- a/src/ross_trading/data/types.py
+++ b/src/ross_trading/data/types.py
@@ -25,6 +25,24 @@ class Side(StrEnum):
     UNKNOWN = "UNKNOWN"
 
 
+class Timeframe(StrEnum):
+    """Bar aggregation periods.
+
+    Not every provider supports every timeframe (10-second bars are a
+    known gap — see decision issue #14). Providers should expose
+    ``supported_timeframes`` so callers can fail fast.
+    """
+
+    S1 = "S1"
+    S10 = "S10"
+    M1 = "M1"
+    M5 = "M5"
+    D1 = "D1"
+
+
+_VALID_TIMEFRAMES: frozenset[str] = frozenset(t.value for t in Timeframe)
+
+
 @dataclass(frozen=True, slots=True)
 class Quote:
     """Top-of-book quote (NBBO)."""
@@ -58,6 +76,12 @@ class Bar:
 
     def __post_init__(self) -> None:
         _require_utc(self.ts, "Bar.ts")
+        if self.timeframe not in _VALID_TIMEFRAMES:
+            msg = (
+                f"Bar.timeframe must be a Timeframe value "
+                f"(one of {sorted(_VALID_TIMEFRAMES)}), got {self.timeframe!r}"
+            )
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ross_trading/data/types.py
+++ b/src/ross_trading/data/types.py
@@ -1,0 +1,133 @@
+"""Frozen value types emitted by data providers.
+
+Prices are ``Decimal`` so equality and arithmetic are exact (bid/ask
+spreads of $0.01 must not drift through float rounding). Timestamps
+are tz-aware UTC; provider implementations are responsible for
+converting vendor-native zones (often ET) before emitting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+
+
+class Side(StrEnum):
+    """Trade side as recorded on the tape."""
+
+    BUY = "BUY"
+    SELL = "SELL"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True, slots=True)
+class Quote:
+    """Top-of-book quote (NBBO)."""
+
+    symbol: str
+    ts: datetime
+    bid: Decimal
+    ask: Decimal
+    bid_size: int
+    ask_size: int
+
+    def __post_init__(self) -> None:
+        _require_utc(self.ts, "Quote.ts")
+
+
+@dataclass(frozen=True, slots=True)
+class Bar:
+    """OHLCV bar at a fixed timeframe.
+
+    ``ts`` is the bar's *open* time (left edge of the interval).
+    """
+
+    symbol: str
+    ts: datetime
+    timeframe: str
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: int
+
+    def __post_init__(self) -> None:
+        _require_utc(self.ts, "Bar.ts")
+
+
+@dataclass(frozen=True, slots=True)
+class Tape:
+    """Single trade execution as printed on the consolidated tape."""
+
+    symbol: str
+    ts: datetime
+    price: Decimal
+    size: int
+    side: Side = Side.UNKNOWN
+
+    def __post_init__(self) -> None:
+        _require_utc(self.ts, "Tape.ts")
+
+
+@dataclass(frozen=True, slots=True)
+class Headline:
+    """News headline event.
+
+    ``dedup_key`` is the canonical identity used by ``HeadlineDeduper`` —
+    same key within the dedup window means "same story", even if two
+    sources report it.
+    """
+
+    ticker: str
+    ts: datetime
+    source: str
+    title: str
+    url: str | None = None
+    body: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_utc(self.ts, "Headline.ts")
+
+    @property
+    def dedup_key(self) -> tuple[str, str, str]:
+        return (self.source, _normalize_title(self.title), self.ticker.upper())
+
+
+@dataclass(frozen=True, slots=True)
+class FloatRecord:
+    """Daily float-reference snapshot for a ticker."""
+
+    ticker: str
+    as_of: date
+    float_shares: int
+    shares_outstanding: int
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class FeedGap:
+    """Emitted by the reconnect wrapper to mark a window of missed events."""
+
+    symbol: str | None
+    start: datetime
+    end: datetime
+    reason: str
+
+    def __post_init__(self) -> None:
+        _require_utc(self.start, "FeedGap.start")
+        _require_utc(self.end, "FeedGap.end")
+
+
+def _require_utc(ts: datetime, field: str) -> None:
+    if ts.tzinfo is None or ts.tzinfo.utcoffset(ts) != UTC.utcoffset(ts):
+        msg = f"{field} must be tz-aware UTC, got {ts.tzinfo!r}"
+        raise ValueError(msg)
+
+
+def _normalize_title(title: str) -> str:
+    return " ".join(title.lower().split())

--- a/src/ross_trading/indicators/ema.py
+++ b/src/ross_trading/indicators/ema.py
@@ -1,1 +1,48 @@
-"""EMA(9, 20, 50, 200). TA-Lib parity required. See issue #1, arch §3.3 / §3.4.2."""
+"""Exponential moving average.
+
+Initialization uses the SMA of the first ``period`` values, which is
+the convention TA-Lib uses (and what most charting platforms display).
+Returned series is the same length as the input; positions before the
+initialization window are filled with the running prefix mean so
+callers don't need to worry about ``None`` slots.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def ema_alpha(period: int) -> Decimal:
+    if period <= 0:
+        msg = "period must be positive"
+        raise ValueError(msg)
+    return Decimal(2) / (Decimal(period) + Decimal(1))
+
+
+def ema_series(values: Sequence[Decimal], period: int) -> list[Decimal]:
+    if period <= 0:
+        msg = "period must be positive"
+        raise ValueError(msg)
+    if not values:
+        return []
+    alpha = ema_alpha(period)
+    one_minus_alpha = Decimal(1) - alpha
+    out: list[Decimal] = []
+    running_sum = Decimal(0)
+    seed: Decimal | None = None
+    for i, v in enumerate(values):
+        running_sum += v
+        if i < period - 1:
+            out.append(running_sum / Decimal(i + 1))
+            continue
+        if seed is None:
+            seed = running_sum / Decimal(period)
+            out.append(seed)
+            continue
+        prev = out[-1]
+        out.append(alpha * v + one_minus_alpha * prev)
+    return out

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -1,0 +1,15 @@
+"""Scripted fakes used across the data-layer test suite.
+
+These are *test helpers*, not production code — concrete vendor
+providers belong under ``ross_trading.data.providers``.
+"""
+
+from tests.fakes.float_ref import FakeFloatReferenceProvider
+from tests.fakes.market import FakeMarketDataProvider
+from tests.fakes.news import FakeNewsProvider
+
+__all__ = [
+    "FakeFloatReferenceProvider",
+    "FakeMarketDataProvider",
+    "FakeNewsProvider",
+]

--- a/tests/fakes/float_ref.py
+++ b/tests/fakes/float_ref.py
@@ -1,0 +1,30 @@
+"""Scripted FloatReferenceProvider for tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ross_trading.core.errors import FeedError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from datetime import date
+
+    from ross_trading.data.types import FloatRecord
+
+
+class FakeFloatReferenceProvider:
+    """Returns canned float records keyed on (ticker, as_of)."""
+
+    def __init__(self, records: Mapping[tuple[str, date], FloatRecord]) -> None:
+        self._records = {(t.upper(), d): r for (t, d), r in records.items()}
+        self.calls: list[tuple[str, date]] = []
+
+    async def get_float(self, ticker: str, as_of: date) -> FloatRecord:
+        key = (ticker.upper(), as_of)
+        self.calls.append(key)
+        record = self._records.get(key)
+        if record is None:
+            msg = f"no fake float record for {key}"
+            raise FeedError(msg)
+        return record

--- a/tests/fakes/market.py
+++ b/tests/fakes/market.py
@@ -1,0 +1,86 @@
+"""Scripted MarketDataProvider for tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ross_trading.data.market_feed import Timeframe
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+    from datetime import datetime
+
+    from ross_trading.data.types import Bar, Quote, Tape
+
+
+class FakeMarketDataProvider:
+    """Replays a fixed list of events for a configurable symbol set.
+
+    Events are emitted in declaration order. ``connect`` and
+    ``disconnect`` are idempotent; the provider tracks call counts so
+    tests can assert lifecycle. ``historical_bars`` returns the subset
+    of pre-recorded bars whose timestamp falls in [start, end).
+    """
+
+    def __init__(
+        self,
+        *,
+        quotes: Sequence[Quote] = (),
+        bars: Sequence[Bar] = (),
+        tape: Sequence[Tape] = (),
+        timeframes: Iterable[Timeframe] = (Timeframe.M1, Timeframe.D1),
+    ) -> None:
+        self._quotes = list(quotes)
+        self._bars = list(bars)
+        self._tape = list(tape)
+        self._timeframes = frozenset(timeframes)
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+
+    @property
+    def supported_timeframes(self) -> frozenset[Timeframe]:
+        return self._timeframes
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+
+    async def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]:
+        wanted = {s.upper() for s in symbols}
+        for quote in self._quotes:
+            if quote.symbol.upper() in wanted:
+                yield quote
+
+    async def subscribe_bars(
+        self,
+        symbols: Iterable[str],
+        timeframe: Timeframe,
+    ) -> AsyncIterator[Bar]:
+        wanted = {s.upper() for s in symbols}
+        for bar in self._bars:
+            if bar.symbol.upper() in wanted and bar.timeframe == timeframe.value:
+                yield bar
+
+    async def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]:
+        wanted = {s.upper() for s in symbols}
+        for trade in self._tape:
+            if trade.symbol.upper() in wanted:
+                yield trade
+
+    async def historical_bars(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        timeframe: Timeframe,
+    ) -> Sequence[Bar]:
+        upper = symbol.upper()
+        return [
+            b
+            for b in self._bars
+            if b.symbol.upper() == upper
+            and b.timeframe == timeframe.value
+            and start <= b.ts < end
+        ]

--- a/tests/fakes/news.py
+++ b/tests/fakes/news.py
@@ -1,0 +1,43 @@
+"""Scripted NewsProvider for tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+    from datetime import datetime
+
+    from ross_trading.data.types import Headline
+
+
+class FakeNewsProvider:
+    """Replays a fixed list of headlines."""
+
+    def __init__(self, headlines: Sequence[Headline] = ()) -> None:
+        self._headlines = list(headlines)
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+
+    async def subscribe_headlines(
+        self,
+        symbols: Iterable[str] | None = None,
+    ) -> AsyncIterator[Headline]:
+        wanted = None if symbols is None else {s.upper() for s in symbols}
+        for h in self._headlines:
+            if wanted is None or h.ticker.upper() in wanted:
+                yield h
+
+    async def recent_headlines(
+        self,
+        symbol: str,
+        since: datetime,
+    ) -> Sequence[Headline]:
+        upper = symbol.upper()
+        return [h for h in self._headlines if h.ticker.upper() == upper and h.ts >= since]

--- a/tests/integration/test_replay_day.py
+++ b/tests/integration/test_replay_day.py
@@ -1,0 +1,228 @@
+"""Atom 15 — Phase 1 exit criterion.
+
+> "Can replay a historical trading day from disk through the data
+>  layer with realistic timing." — issue #2
+
+Records a synthetic trading day (quotes, bars, headlines, float)
+through :class:`FeedRecorder`, then plays it back through
+:class:`ReplayProvider` and verifies every stream survives the
+roundtrip and that scanner-shaped queries (relative volume + EMA)
+work against the replayed data.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ross_trading.core.clock import RealClock, VirtualClock
+from ross_trading.data.cache import HistoricalCache
+from ross_trading.data.float_reference import CachedFloatReference
+from ross_trading.data.historical import (
+    populate_daily_volumes,
+    precompute_daily_emas,
+)
+from ross_trading.data.market_feed import Timeframe
+from ross_trading.data.providers.replay import ReplayMode, ReplayProvider
+from ross_trading.data.recorder import FeedRecorder
+from ross_trading.data.types import Bar, FloatRecord, Headline, Quote
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.integration
+
+
+# Pre-market start of a trading day in Cameron's Trading Plan window.
+DAY = date(2026, 4, 26)
+SESSION_START = datetime(2026, 4, 26, 11, 0, tzinfo=UTC)  # 7:00 AM ET
+
+
+def _quote(offset_s: int, bid: str, ask: str) -> Quote:
+    return Quote(
+        symbol="AVTX",
+        ts=SESSION_START + timedelta(seconds=offset_s),
+        bid=Decimal(bid),
+        ask=Decimal(ask),
+        bid_size=500,
+        ask_size=500,
+    )
+
+
+def _bar(offset_s: int, close: str, volume: int = 50_000) -> Bar:
+    return Bar(
+        symbol="AVTX",
+        ts=SESSION_START + timedelta(seconds=offset_s),
+        timeframe="M1",
+        open=Decimal(close),
+        high=Decimal(close),
+        low=Decimal(close),
+        close=Decimal(close),
+        volume=volume,
+    )
+
+
+def _headline(offset_s: int, title: str) -> Headline:
+    return Headline(
+        ticker="AVTX",
+        ts=SESSION_START + timedelta(seconds=offset_s),
+        source="Benzinga",
+        title=title,
+        url=f"https://example.com/{offset_s}",
+    )
+
+
+SCRIPTED_QUOTES = [
+    _quote(0, "4.21", "4.22"),
+    _quote(15, "4.30", "4.31"),
+    _quote(30, "4.45", "4.46"),
+]
+
+SCRIPTED_BARS = [
+    _bar(0, "4.22"),
+    _bar(60, "4.40", volume=120_000),
+    _bar(120, "4.55", volume=200_000),
+]
+
+SCRIPTED_HEADLINES = [
+    _headline(5, "AVTX Phase 3 Trial Hits Primary Endpoint"),
+    _headline(70, "AVTX Confirms No Dilutive Offering Pending"),
+]
+
+SCRIPTED_FLOAT = FloatRecord(
+    ticker="AVTX",
+    as_of=DAY,
+    float_shares=8_500_000,
+    shares_outstanding=12_000_000,
+    source="benzinga",
+)
+
+
+async def _record_session(out_dir: Path) -> None:
+    async with FeedRecorder(out_dir) as rec:
+        for q in SCRIPTED_QUOTES:
+            rec.record_quote(q)
+        for b in SCRIPTED_BARS:
+            rec.record_bar(b)
+        for h in SCRIPTED_HEADLINES:
+            rec.record_headline(h)
+        rec.record_float(SCRIPTED_FLOAT)
+
+
+async def test_replay_full_session_roundtrip(tmp_path: Path) -> None:
+    await _record_session(tmp_path)
+
+    replay = ReplayProvider(tmp_path, mode=ReplayMode.AS_FAST_AS_POSSIBLE)
+    await replay.connect()
+
+    quotes = [q async for q in replay.subscribe_quotes(["AVTX"])]
+    bars = [b async for b in replay.subscribe_bars(["AVTX"], Timeframe.M1)]
+    heads = [h async for h in replay.subscribe_headlines(["AVTX"])]
+    float_rec = await replay.get_float("AVTX", DAY)
+
+    assert [q.bid for q in quotes] == [Decimal("4.21"), Decimal("4.30"), Decimal("4.45")]
+    assert [b.close for b in bars] == [Decimal("4.22"), Decimal("4.40"), Decimal("4.55")]
+    assert [h.title for h in heads] == [h.title for h in SCRIPTED_HEADLINES]
+    assert float_rec.float_shares == 8_500_000
+
+
+async def test_replay_realtime_mode_paces_intervals(tmp_path: Path) -> None:
+    await _record_session(tmp_path)
+
+    clock = VirtualClock(SESSION_START)
+    replay = ReplayProvider(tmp_path, mode=ReplayMode.REALTIME, clock=clock)
+    await replay.connect()
+
+    real = RealClock()
+    real_t0 = real.monotonic()
+    bars = [b async for b in replay.subscribe_bars(["AVTX"], Timeframe.M1)]
+    real_elapsed = real.monotonic() - real_t0
+
+    # Three bars at 0s, 60s, 120s. VirtualClock advances 120s; wall
+    # clock stays small because VirtualClock.sleep doesn't block.
+    assert clock.monotonic() == pytest.approx(120.0, abs=0.5)
+    assert real_elapsed < 1.0
+    assert len(bars) == 3
+
+
+async def test_replay_realtime_with_real_clock_actually_paces(tmp_path: Path) -> None:
+    """Spot-check that under :class:`RealClock`, pacing introduces real delay."""
+    quick_dir = tmp_path / "quick"
+    async with FeedRecorder(quick_dir) as rec:
+        for offset_ms in (0, 50, 100, 150):
+            rec.record_quote(
+                Quote(
+                    symbol="AVTX",
+                    ts=SESSION_START + timedelta(milliseconds=offset_ms),
+                    bid=Decimal("1"),
+                    ask=Decimal("1.01"),
+                    bid_size=1,
+                    ask_size=1,
+                )
+            )
+
+    replay = ReplayProvider(quick_dir, mode=ReplayMode.REALTIME, clock=RealClock())
+    await replay.connect()
+
+    real = RealClock()
+    t0 = real.monotonic()
+    out = [q async for q in replay.subscribe_quotes(["AVTX"])]
+    elapsed = real.monotonic() - t0
+
+    assert len(out) == 4
+    # Original spans 0.15s; pacing should make this take ≥0.10s
+    # (some leeway for asyncio scheduling on Windows).
+    assert elapsed >= 0.10
+
+
+async def test_replay_supports_relative_volume_and_ema_lookups(tmp_path: Path) -> None:
+    """Atom 15 — replayed historical data feeds the scanner filters."""
+    # Synthesize 250 days of daily bars via a separate recording directory.
+    daily_dir = tmp_path / "daily"
+    async with FeedRecorder(daily_dir) as rec:
+        for i in range(250):
+            day = DAY - timedelta(days=i)
+            ts = datetime.combine(day, datetime.min.time(), tzinfo=UTC)
+            rec.record_bar(
+                Bar(
+                    symbol="AVTX",
+                    ts=ts,
+                    timeframe="D1",
+                    open=Decimal("10"),
+                    high=Decimal("10"),
+                    low=Decimal("10"),
+                    close=Decimal("10") + Decimal(i % 5),
+                    volume=1_000_000,
+                )
+            )
+
+    replay = ReplayProvider(daily_dir)
+    await replay.connect()
+
+    cache = HistoricalCache(tmp_path / "h.sqlite")
+    await populate_daily_volumes(replay, "AVTX", end_inclusive=DAY, cache=cache)
+    await precompute_daily_emas(
+        replay, "AVTX", end_inclusive=DAY, cache=cache, history_days=250
+    )
+
+    rel_vol = cache.relative_volume("AVTX", DAY, today_volume=5_000_000)
+    assert rel_vol is not None
+    assert rel_vol == Decimal("5")
+    ema_20 = cache.ema("AVTX", DAY, 20)
+    assert ema_20 is not None
+    cache.close()
+
+
+async def test_cached_float_reference_in_front_of_replay(tmp_path: Path) -> None:
+    await _record_session(tmp_path)
+    replay = ReplayProvider(tmp_path)
+    await replay.connect()
+    cached = CachedFloatReference(replay)
+
+    # Two lookups → only one upstream replay scan (the second hits cache).
+    a = await cached.get_float("AVTX", DAY)
+    b = await cached.get_float("AVTX", DAY)
+    assert a == b

--- a/tests/integration/test_replay_day.py
+++ b/tests/integration/test_replay_day.py
@@ -36,9 +36,11 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.integration
 
 
-# Pre-market start of a trading day in Cameron's Trading Plan window.
-DAY = date(2026, 4, 26)
-SESSION_START = datetime(2026, 4, 26, 11, 0, tzinfo=UTC)  # 7:00 AM ET
+# Stable historical date — 2025-01-02 is the first regular trading day
+# of 2025. We pin this so the test isn't sensitive to wall-clock drift.
+# 12:00 UTC = 7:00 AM EST, the start of Cameron's Trading Plan window.
+DAY = date(2025, 1, 2)
+SESSION_START = datetime(2025, 1, 2, 12, 0, tzinfo=UTC)  # 7:00 AM EST
 
 
 def _quote(offset_s: int, bid: str, ask: str) -> Quote:

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -1,0 +1,48 @@
+"""VirtualClock + RealClock contract tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ross_trading.core.clock import Clock, RealClock, VirtualClock
+
+
+def test_real_clock_satisfies_protocol() -> None:
+    assert isinstance(RealClock(), Clock)
+
+
+def test_virtual_clock_satisfies_protocol() -> None:
+    assert isinstance(VirtualClock(datetime(2026, 4, 26, tzinfo=UTC)), Clock)
+
+
+def test_virtual_clock_rejects_naive_start() -> None:
+    with pytest.raises(ValueError, match="tz-aware"):
+        VirtualClock(datetime(2026, 4, 26))
+
+
+def test_virtual_clock_advance_moves_now_and_monotonic() -> None:
+    start = datetime(2026, 4, 26, 13, 30, tzinfo=UTC)
+    clock = VirtualClock(start)
+    clock.advance(2.5)
+    assert clock.now() == start + timedelta(seconds=2.5)
+    assert clock.monotonic() == pytest.approx(2.5)
+
+
+def test_virtual_clock_set_time_forward_only() -> None:
+    start = datetime(2026, 4, 26, 13, 30, tzinfo=UTC)
+    clock = VirtualClock(start)
+    clock.set_time(start + timedelta(minutes=5))
+    assert clock.now() == start + timedelta(minutes=5)
+    with pytest.raises(ValueError, match="cannot move backwards"):
+        clock.set_time(start)
+
+
+async def test_virtual_clock_sleep_does_not_block_wall_time() -> None:
+    real = RealClock()
+    clock = VirtualClock(datetime(2026, 4, 26, tzinfo=UTC))
+    t0 = real.monotonic()
+    await clock.sleep(60.0)
+    assert real.monotonic() - t0 < 0.5
+    assert clock.monotonic() == pytest.approx(60.0)

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -1,0 +1,89 @@
+"""Atom 1 — sanity checks for data layer value types."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+from ross_trading.data import Bar, FeedGap, FloatRecord, Headline, Quote, Side, Tape
+
+UTC_NOW = datetime(2026, 4, 26, 14, 30, tzinfo=UTC)
+
+
+def test_quote_is_frozen_and_hashable() -> None:
+    quote = Quote(
+        symbol="AVTX",
+        ts=UTC_NOW,
+        bid=Decimal("4.21"),
+        ask=Decimal("4.22"),
+        bid_size=100,
+        ask_size=200,
+    )
+    with pytest.raises(FrozenInstanceError):
+        quote.bid = Decimal("0")  # type: ignore[misc]
+    assert hash(quote) == hash(quote)
+
+
+def test_bar_rejects_naive_timestamp() -> None:
+    with pytest.raises(ValueError, match="tz-aware UTC"):
+        Bar(
+            symbol="AVTX",
+            ts=datetime(2026, 4, 26, 14, 30),  # naive
+            timeframe="M1",
+            open=Decimal("4.20"),
+            high=Decimal("4.30"),
+            low=Decimal("4.18"),
+            close=Decimal("4.25"),
+            volume=12_345,
+        )
+
+
+def test_tape_defaults_to_unknown_side() -> None:
+    tape = Tape(symbol="AVTX", ts=UTC_NOW, price=Decimal("4.22"), size=500)
+    assert tape.side is Side.UNKNOWN
+
+
+def test_headline_dedup_key_normalizes_title_and_ticker() -> None:
+    a = Headline(
+        ticker="avtx",
+        ts=UTC_NOW,
+        source="Benzinga",
+        title="  AVTX Announces  Phase 3 Trial Success ",
+    )
+    b = Headline(
+        ticker="AVTX",
+        ts=UTC_NOW,
+        source="Benzinga",
+        title="AVTX Announces Phase 3 Trial Success",
+    )
+    assert a.dedup_key == b.dedup_key
+
+
+def test_headline_dedup_key_distinguishes_sources() -> None:
+    a = Headline(ticker="AVTX", ts=UTC_NOW, source="Benzinga", title="x")
+    b = Headline(ticker="AVTX", ts=UTC_NOW, source="Polygon", title="x")
+    assert a.dedup_key != b.dedup_key
+
+
+def test_float_record_holds_date() -> None:
+    rec = FloatRecord(
+        ticker="AVTX",
+        as_of=date(2026, 4, 26),
+        float_shares=8_500_000,
+        shares_outstanding=12_000_000,
+        source="benzinga",
+    )
+    assert rec.as_of == date(2026, 4, 26)
+
+
+def test_feed_gap_validates_both_ends_utc() -> None:
+    with pytest.raises(ValueError, match="tz-aware UTC"):
+        FeedGap(
+            symbol="AVTX",
+            start=UTC_NOW,
+            end=datetime(2026, 4, 26, 14, 31),  # naive
+            reason="websocket-closed",
+        )

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -46,6 +46,20 @@ def test_tape_defaults_to_unknown_side() -> None:
     assert tape.side is Side.UNKNOWN
 
 
+def test_bar_rejects_unknown_timeframe() -> None:
+    with pytest.raises(ValueError, match="must be a Timeframe value"):
+        Bar(
+            symbol="AVTX",
+            ts=UTC_NOW,
+            timeframe="banana",
+            open=Decimal("4.20"),
+            high=Decimal("4.30"),
+            low=Decimal("4.18"),
+            close=Decimal("4.25"),
+            volume=12_345,
+        )
+
+
 def test_headline_dedup_key_normalizes_title_and_ticker() -> None:
     a = Headline(
         ticker="avtx",

--- a/tests/unit/test_float_reference.py
+++ b/tests/unit/test_float_reference.py
@@ -1,0 +1,70 @@
+"""Atoms 4 & 11 — FloatReferenceProvider protocol + CachedFloatReference."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from ross_trading.core.clock import VirtualClock
+from ross_trading.data.float_reference import (
+    CachedFloatReference,
+    FloatReferenceProvider,
+)
+from ross_trading.data.types import FloatRecord
+
+
+class _CountingProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get_float(self, ticker: str, as_of: date) -> FloatRecord:
+        self.calls += 1
+        return FloatRecord(
+            ticker=ticker.upper(),
+            as_of=as_of,
+            float_shares=8_500_000,
+            shares_outstanding=12_000_000,
+            source="counting",
+        )
+
+
+def test_counting_provider_satisfies_protocol() -> None:
+    assert isinstance(_CountingProvider(), FloatReferenceProvider)
+
+
+async def test_cache_hit_does_not_call_upstream() -> None:
+    upstream = _CountingProvider()
+    clock = VirtualClock(datetime(2026, 4, 26, tzinfo=UTC))
+    cache = CachedFloatReference(upstream, clock=clock)
+    await cache.get_float("AVTX", date(2026, 4, 26))
+    await cache.get_float("avtx", date(2026, 4, 26))
+    await cache.get_float("AVTX", date(2026, 4, 26))
+    assert upstream.calls == 1
+
+
+async def test_cache_misses_after_ttl() -> None:
+    upstream = _CountingProvider()
+    clock = VirtualClock(datetime(2026, 4, 26, tzinfo=UTC))
+    cache = CachedFloatReference(upstream, clock=clock, ttl=timedelta(hours=1))
+    await cache.get_float("AVTX", date(2026, 4, 26))
+    clock.advance(3601)
+    await cache.get_float("AVTX", date(2026, 4, 26))
+    assert upstream.calls == 2
+
+
+async def test_invalidate_drops_all_dates_for_ticker() -> None:
+    upstream = _CountingProvider()
+    cache = CachedFloatReference(upstream)
+    await cache.get_float("AVTX", date(2026, 4, 26))
+    await cache.get_float("AVTX", date(2026, 4, 25))
+    await cache.get_float("BBAI", date(2026, 4, 26))
+    dropped = cache.invalidate("AVTX")
+    assert dropped == 2
+    await cache.get_float("AVTX", date(2026, 4, 26))
+    assert upstream.calls == 4  # initial 3 + 1 refetch after invalidate
+
+
+def test_cache_rejects_zero_ttl() -> None:
+    with pytest.raises(ValueError, match="ttl must be positive"):
+        CachedFloatReference(_CountingProvider(), ttl=timedelta(0))

--- a/tests/unit/test_historical.py
+++ b/tests/unit/test_historical.py
@@ -1,0 +1,115 @@
+"""Atoms 9 & 10 — HistoricalCache + populate_daily_volumes + precompute_daily_emas."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ross_trading.data.cache import HistoricalCache
+from ross_trading.data.historical import (
+    populate_daily_volumes,
+    precompute_daily_emas,
+)
+from ross_trading.data.types import Bar
+from ross_trading.indicators.ema import ema_alpha, ema_series
+from tests.fakes import FakeMarketDataProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+T0 = datetime(2026, 4, 26, tzinfo=UTC)
+
+
+def _bar(symbol: str, day_offset: int, close: str, volume: int) -> Bar:
+    ts = T0 - timedelta(days=day_offset)
+    return Bar(
+        symbol=symbol,
+        ts=ts,
+        timeframe="D1",
+        open=Decimal(close),
+        high=Decimal(close),
+        low=Decimal(close),
+        close=Decimal(close),
+        volume=volume,
+    )
+
+
+def test_avg_daily_volume_uses_last_n() -> None:
+    cache = HistoricalCache()
+    rows = [("AVTX", date(2026, 4, 26) - timedelta(days=i), 100 * (i + 1)) for i in range(40)]
+    cache.record_daily_volumes(rows)
+    avg = cache.avg_daily_volume("AVTX", date(2026, 4, 26), lookback_days=30)
+    assert avg is not None
+    expected = sum(100 * (i + 1) for i in range(30)) / 30
+    assert avg == Decimal(str(expected))
+    cache.close()
+
+
+def test_relative_volume_excludes_today() -> None:
+    cache = HistoricalCache()
+    today = date(2026, 4, 26)
+    # 30 days of 1000 volume, prior to today.
+    rows = [("AVTX", today - timedelta(days=i + 1), 1000) for i in range(30)]
+    cache.record_daily_volumes(rows)
+    rel = cache.relative_volume("AVTX", today, today_volume=5_000)
+    assert rel == Decimal("5")
+    cache.close()
+
+
+def test_relative_volume_returns_none_with_no_history() -> None:
+    cache = HistoricalCache()
+    rel = cache.relative_volume("AVTX", date(2026, 4, 26), today_volume=1000)
+    assert rel is None
+    cache.close()
+
+
+def test_ema_alpha_period_3() -> None:
+    assert ema_alpha(3) == Decimal("0.5")
+
+
+def test_ema_series_matches_known_values() -> None:
+    values = [Decimal(v) for v in [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]]
+    out = ema_series(values, period=3)
+    # SMA of first 3 = 11; alpha = 0.5
+    assert out[2] == Decimal("11")
+    assert out[3] == Decimal("12")  # 0.5*13 + 0.5*11 = 12
+    assert out[4] == Decimal("13")  # 0.5*14 + 0.5*12 = 13
+
+
+def test_ema_alpha_rejects_zero_period() -> None:
+    with pytest.raises(ValueError, match="period must be positive"):
+        ema_alpha(0)
+
+
+async def test_populate_daily_volumes_writes_to_cache(tmp_path: Path) -> None:
+    bars = [_bar("AVTX", i, "10", 1_000_000 + i) for i in range(30)]
+    provider = FakeMarketDataProvider(bars=bars)
+    cache = HistoricalCache(tmp_path / "h.sqlite")
+    written = await populate_daily_volumes(
+        provider, "AVTX", end_inclusive=T0.date(), cache=cache
+    )
+    assert written == 30
+    avg = cache.avg_daily_volume("AVTX", T0.date(), lookback_days=30)
+    assert avg is not None
+    assert avg > Decimal("999_000")
+    cache.close()
+
+
+async def test_precompute_daily_emas_persists_all_periods(tmp_path: Path) -> None:
+    bars = [_bar("AVTX", 249 - i, str(10 + (i % 5)), 1_000_000) for i in range(250)]
+    provider = FakeMarketDataProvider(bars=bars)
+    cache = HistoricalCache(tmp_path / "h.sqlite")
+    written = await precompute_daily_emas(
+        provider, "AVTX", end_inclusive=T0.date(), cache=cache, history_days=250
+    )
+    assert written == 250 * 3
+    val_20 = cache.ema("AVTX", T0.date(), 20)
+    val_50 = cache.ema("AVTX", T0.date(), 50)
+    val_200 = cache.ema("AVTX", T0.date(), 200)
+    assert val_20 is not None
+    assert val_50 is not None
+    assert val_200 is not None
+    cache.close()

--- a/tests/unit/test_market_feed.py
+++ b/tests/unit/test_market_feed.py
@@ -1,0 +1,75 @@
+"""Atom 2 — MarketDataProvider protocol contract."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ross_trading.data.market_feed import MarketDataProvider, Timeframe
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+    from datetime import datetime
+
+    from ross_trading.data.types import Bar, Quote, Tape
+
+
+class _Stub:
+    @property
+    def supported_timeframes(self) -> frozenset[Timeframe]:
+        return frozenset({Timeframe.M1})
+
+    async def connect(self) -> None:
+        return
+
+    async def disconnect(self) -> None:
+        return
+
+    async def _empty_quotes(self) -> AsyncIterator[Quote]:
+        if False:
+            yield  # pragma: no cover
+
+    def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]:
+        del symbols
+        return self._empty_quotes()
+
+    async def _empty_bars(self) -> AsyncIterator[Bar]:
+        if False:
+            yield  # pragma: no cover
+
+    def subscribe_bars(
+        self,
+        symbols: Iterable[str],
+        timeframe: Timeframe,
+    ) -> AsyncIterator[Bar]:
+        del symbols, timeframe
+        return self._empty_bars()
+
+    async def _empty_tape(self) -> AsyncIterator[Tape]:
+        if False:
+            yield  # pragma: no cover
+
+    def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]:
+        del symbols
+        return self._empty_tape()
+
+    async def historical_bars(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        timeframe: Timeframe,
+    ) -> Sequence[Bar]:
+        del symbol, start, end, timeframe
+        return []
+
+
+def test_stub_satisfies_protocol() -> None:
+    assert isinstance(_Stub(), MarketDataProvider)
+
+
+def test_timeframe_values_are_stable_strings() -> None:
+    assert Timeframe.S1.value == "S1"
+    assert Timeframe.S10.value == "S10"
+    assert Timeframe.M1.value == "M1"
+    assert Timeframe.M5.value == "M5"
+    assert Timeframe.D1.value == "D1"

--- a/tests/unit/test_news_feed.py
+++ b/tests/unit/test_news_feed.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from ross_trading.core.clock import VirtualClock
 from ross_trading.data.news_feed import HeadlineDeduper
 from ross_trading.data.types import Headline
 
@@ -23,37 +22,51 @@ def _h(
 
 
 def test_deduper_flags_exact_duplicate() -> None:
-    clock = VirtualClock(T0)
-    deduper = HeadlineDeduper(clock=clock)
+    deduper = HeadlineDeduper()
     assert deduper.is_duplicate(_h()) is False
     assert deduper.is_duplicate(_h()) is True
 
 
 def test_deduper_normalizes_whitespace_and_case() -> None:
-    clock = VirtualClock(T0)
-    deduper = HeadlineDeduper(clock=clock)
+    deduper = HeadlineDeduper()
     deduper.is_duplicate(_h(title="AVTX up on FDA approval"))
     assert deduper.is_duplicate(_h(title="  avtx UP  ON  fda APPROVAL ")) is True
 
 
 def test_deduper_distinguishes_sources() -> None:
-    clock = VirtualClock(T0)
-    deduper = HeadlineDeduper(clock=clock)
+    deduper = HeadlineDeduper()
     deduper.is_duplicate(_h(source="Benzinga"))
     assert deduper.is_duplicate(_h(source="Polygon")) is False
 
 
-def test_deduper_evicts_after_window() -> None:
-    clock = VirtualClock(T0)
-    deduper = HeadlineDeduper(window=timedelta(hours=1), clock=clock)
-    deduper.is_duplicate(_h())
-    clock.advance(3601)
-    assert deduper.is_duplicate(_h()) is False
+def test_deduper_evicts_after_window_using_event_time() -> None:
+    """Eviction must work without a clock — drives off headline.ts."""
+    deduper = HeadlineDeduper(window=timedelta(hours=1))
+    deduper.is_duplicate(_h(ts=T0))
+    later = _h(ts=T0 + timedelta(hours=1, seconds=1))
+    assert deduper.is_duplicate(later) is False
+
+
+def test_deduper_works_under_fast_replay() -> None:
+    """Regression: under AS_FAST_AS_POSSIBLE replay, no clock advance
+    happens. Eviction must still fire because it keys off headline.ts."""
+    deduper = HeadlineDeduper(window=timedelta(hours=1))
+    for i in range(10):
+        ts = T0 + timedelta(hours=i)
+        # Each headline is unique by title, so they all insert.
+        # The expiry pass on each insert evicts older ones.
+        h = _h(title=f"story {i}", ts=ts)
+        deduper.is_duplicate(h)
+    # By story 9 (T0 + 9h), only stories within the 1h window survive.
+    earliest_still_valid = _h(title="story 9", ts=T0 + timedelta(hours=9))
+    assert deduper.is_duplicate(earliest_still_valid) is True
+    # story 0 is long gone — re-inserting is a fresh entry, not a dup.
+    fresh = _h(title="story 0", ts=T0 + timedelta(hours=9))
+    assert deduper.is_duplicate(fresh) is False
 
 
 def test_deduper_respects_max_entries() -> None:
-    clock = VirtualClock(T0)
-    deduper = HeadlineDeduper(clock=clock, max_entries=3)
+    deduper = HeadlineDeduper(max_entries=3)
     for i in range(5):
         deduper.is_duplicate(_h(title=f"story {i}"))
     # First two should have been evicted by capacity bound.

--- a/tests/unit/test_news_feed.py
+++ b/tests/unit/test_news_feed.py
@@ -1,0 +1,66 @@
+"""Atom 3 — NewsProvider protocol + HeadlineDeduper."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ross_trading.core.clock import VirtualClock
+from ross_trading.data.news_feed import HeadlineDeduper
+from ross_trading.data.types import Headline
+
+T0 = datetime(2026, 4, 26, 14, 30, tzinfo=UTC)
+
+
+def _h(
+    title: str = "AVTX up on FDA approval",
+    source: str = "Benzinga",
+    ticker: str = "AVTX",
+    ts: datetime | None = None,
+) -> Headline:
+    return Headline(ticker=ticker, ts=ts or T0, source=source, title=title)
+
+
+def test_deduper_flags_exact_duplicate() -> None:
+    clock = VirtualClock(T0)
+    deduper = HeadlineDeduper(clock=clock)
+    assert deduper.is_duplicate(_h()) is False
+    assert deduper.is_duplicate(_h()) is True
+
+
+def test_deduper_normalizes_whitespace_and_case() -> None:
+    clock = VirtualClock(T0)
+    deduper = HeadlineDeduper(clock=clock)
+    deduper.is_duplicate(_h(title="AVTX up on FDA approval"))
+    assert deduper.is_duplicate(_h(title="  avtx UP  ON  fda APPROVAL ")) is True
+
+
+def test_deduper_distinguishes_sources() -> None:
+    clock = VirtualClock(T0)
+    deduper = HeadlineDeduper(clock=clock)
+    deduper.is_duplicate(_h(source="Benzinga"))
+    assert deduper.is_duplicate(_h(source="Polygon")) is False
+
+
+def test_deduper_evicts_after_window() -> None:
+    clock = VirtualClock(T0)
+    deduper = HeadlineDeduper(window=timedelta(hours=1), clock=clock)
+    deduper.is_duplicate(_h())
+    clock.advance(3601)
+    assert deduper.is_duplicate(_h()) is False
+
+
+def test_deduper_respects_max_entries() -> None:
+    clock = VirtualClock(T0)
+    deduper = HeadlineDeduper(clock=clock, max_entries=3)
+    for i in range(5):
+        deduper.is_duplicate(_h(title=f"story {i}"))
+    # First two should have been evicted by capacity bound.
+    assert deduper.is_duplicate(_h(title="story 0")) is False
+    assert deduper.is_duplicate(_h(title="story 4")) is True
+
+
+def test_deduper_rejects_zero_window() -> None:
+    with pytest.raises(ValueError, match="window must be positive"):
+        HeadlineDeduper(window=timedelta(0))

--- a/tests/unit/test_reconnect.py
+++ b/tests/unit/test_reconnect.py
@@ -1,0 +1,205 @@
+"""Atom 8 — ReconnectingProvider behavior under disconnects."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ross_trading.core.clock import VirtualClock
+from ross_trading.core.errors import FeedDisconnected
+from ross_trading.data.market_feed import Timeframe
+from ross_trading.data.reconnect import ReconnectingProvider
+from ross_trading.data.types import Bar, FeedGap, Quote, Tape
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+
+T0 = datetime(2026, 4, 26, 13, 30, tzinfo=UTC)
+
+
+def _bar(symbol: str, offset: int) -> Bar:
+    return Bar(
+        symbol=symbol,
+        ts=T0 + timedelta(seconds=offset),
+        timeframe="M1",
+        open=Decimal("1"),
+        high=Decimal("1"),
+        low=Decimal("1"),
+        close=Decimal("1"),
+        volume=1,
+    )
+
+
+def _quote(symbol: str, offset: int) -> Quote:
+    return Quote(
+        symbol=symbol,
+        ts=T0 + timedelta(seconds=offset),
+        bid=Decimal("1"),
+        ask=Decimal("1.01"),
+        bid_size=1,
+        ask_size=1,
+    )
+
+
+class _FlakyMarket:
+    """Emits each scripted event exactly once across all subscribes,
+    raising :class:`FeedDisconnected` once after ``drop_after`` events."""
+
+    def __init__(
+        self,
+        live_quotes: Sequence[Quote],
+        live_bars: Sequence[Bar],
+        backfill_bars: Sequence[Bar],
+        drop_after: int,
+    ) -> None:
+        self._remaining_quotes = list(live_quotes)
+        self._remaining_bars = list(live_bars)
+        self._backfill_bars = list(backfill_bars)
+        self._drop_after = drop_after
+        self._dropped = False
+        self.connect_calls = 0
+
+    @property
+    def supported_timeframes(self) -> frozenset[Timeframe]:
+        return frozenset({Timeframe.M1})
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+
+    async def disconnect(self) -> None:
+        return
+
+    async def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]:
+        del symbols
+        emitted_this_call = 0
+        while self._remaining_quotes:
+            if not self._dropped and emitted_this_call == self._drop_after:
+                self._dropped = True
+                raise FeedDisconnected("websocket-closed")
+            yield self._remaining_quotes.pop(0)
+            emitted_this_call += 1
+
+    async def subscribe_bars(
+        self,
+        symbols: Iterable[str],
+        timeframe: Timeframe,
+    ) -> AsyncIterator[Bar]:
+        del symbols, timeframe
+        emitted_this_call = 0
+        while self._remaining_bars:
+            if not self._dropped and emitted_this_call == self._drop_after:
+                self._dropped = True
+                raise FeedDisconnected("websocket-closed")
+            yield self._remaining_bars.pop(0)
+            emitted_this_call += 1
+
+    async def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]:
+        del symbols
+        if False:
+            yield  # pragma: no cover
+
+    async def historical_bars(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        timeframe: Timeframe,
+    ) -> Sequence[Bar]:
+        del timeframe
+        return [b for b in self._backfill_bars if b.symbol == symbol and start <= b.ts < end]
+
+
+async def test_reconnect_emits_gap_for_quotes() -> None:
+    upstream = _FlakyMarket(
+        live_quotes=[_quote("AVTX", 0), _quote("AVTX", 1)],
+        live_bars=[],
+        backfill_bars=[],
+        drop_after=1,
+    )
+    gaps: list[FeedGap] = []
+    clock = VirtualClock(T0)
+    wrapper = ReconnectingProvider(upstream, on_gap=gaps.append, clock=clock, max_retries=2)
+    await wrapper.connect()
+    out = [q async for q in wrapper.subscribe_quotes(["AVTX"])]
+    # First quote → drop → reconnect → second quote. Consumer sees a
+    # continuous 2-event stream and one FeedGap fires for the window.
+    assert [q.ts for q in out] == [T0, T0 + timedelta(seconds=1)]
+    assert len(gaps) == 1
+    assert gaps[0].symbol is None
+    assert gaps[0].start == T0  # last seen ts before the disconnect
+
+
+async def test_reconnect_backfills_bars_after_disconnect() -> None:
+    upstream = _FlakyMarket(
+        live_quotes=[],
+        live_bars=[_bar("AVTX", 0), _bar("AVTX", 60)],
+        backfill_bars=[_bar("AVTX", 30), _bar("AVTX", 45)],
+        drop_after=1,
+    )
+    gaps: list[FeedGap] = []
+    clock = VirtualClock(T0 + timedelta(minutes=2))
+    wrapper = ReconnectingProvider(upstream, on_gap=gaps.append, clock=clock, max_retries=2)
+    await wrapper.connect()
+    bars = [b async for b in wrapper.subscribe_bars(["AVTX"], Timeframe.M1)]
+    # Live first bar (T0), then drop → reconnect → backfill in (T0, gap_end)
+    # → resumed live stream yields the remaining bar (T0+60s).
+    assert [b.ts for b in bars] == [
+        T0,
+        T0 + timedelta(seconds=30),
+        T0 + timedelta(seconds=45),
+        T0 + timedelta(seconds=60),
+    ]
+    assert len(gaps) == 1
+    assert gaps[0].start == T0
+    assert upstream.connect_calls == 2  # initial + one reconnect
+
+
+async def test_max_retries_propagates_disconnect() -> None:
+    class _AlwaysFails:
+        @property
+        def supported_timeframes(self) -> frozenset[Timeframe]:
+            return frozenset()
+
+        async def connect(self) -> None:
+            return
+
+        async def disconnect(self) -> None:
+            return
+
+        async def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]:
+            del symbols
+            raise FeedDisconnected("dead")
+            yield  # pragma: no cover
+
+        async def subscribe_bars(
+            self,
+            symbols: Iterable[str],
+            timeframe: Timeframe,
+        ) -> AsyncIterator[Bar]:
+            del symbols, timeframe
+            if False:
+                yield  # pragma: no cover
+
+        async def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]:
+            del symbols
+            if False:
+                yield  # pragma: no cover
+
+        async def historical_bars(
+            self,
+            symbol: str,
+            start: datetime,
+            end: datetime,
+            timeframe: Timeframe,
+        ) -> Sequence[Bar]:
+            del symbol, start, end, timeframe
+            return []
+
+    clock = VirtualClock(T0)
+    wrapper = ReconnectingProvider(_AlwaysFails(), max_retries=0, clock=clock)
+    with pytest.raises(FeedDisconnected):
+        async for _ in wrapper.subscribe_quotes(["AVTX"]):
+            pass

--- a/tests/unit/test_recorder_replay.py
+++ b/tests/unit/test_recorder_replay.py
@@ -1,0 +1,174 @@
+"""Atoms 5 & 6 — FeedRecorder + ReplayProvider roundtrip."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ross_trading.core.clock import RealClock, VirtualClock
+from ross_trading.core.errors import MissingRecordingError
+from ross_trading.data.market_feed import Timeframe
+from ross_trading.data.providers.replay import ReplayMode, ReplayProvider
+from ross_trading.data.recorder import FeedRecorder
+from ross_trading.data.types import Bar, FloatRecord, Headline, Quote, Side, Tape
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+T0 = datetime(2026, 4, 26, 13, 30, tzinfo=UTC)
+
+
+def _quote(symbol: str, offset: int, bid: str, ask: str) -> Quote:
+    return Quote(
+        symbol=symbol,
+        ts=T0 + timedelta(seconds=offset),
+        bid=Decimal(bid),
+        ask=Decimal(ask),
+        bid_size=100,
+        ask_size=100,
+    )
+
+
+def _bar(symbol: str, offset: int, close: str) -> Bar:
+    return Bar(
+        symbol=symbol,
+        ts=T0 + timedelta(seconds=offset),
+        timeframe="M1",
+        open=Decimal(close),
+        high=Decimal(close),
+        low=Decimal(close),
+        close=Decimal(close),
+        volume=10_000,
+    )
+
+
+async def _record_fixture(out: Path) -> None:
+    async with FeedRecorder(out) as rec:
+        rec.record_quote(_quote("AVTX", 0, "4.21", "4.22"))
+        rec.record_quote(_quote("AVTX", 1, "4.23", "4.24"))
+        rec.record_quote(_quote("BBAI", 0, "9.50", "9.52"))
+        rec.record_bar(_bar("AVTX", 0, "4.21"))
+        rec.record_bar(_bar("AVTX", 60, "4.30"))
+        rec.record_tape(
+            Tape(symbol="AVTX", ts=T0, price=Decimal("4.22"), size=500, side=Side.BUY)
+        )
+        rec.record_headline(
+            Headline(
+                ticker="AVTX",
+                ts=T0 + timedelta(seconds=2),
+                source="Benzinga",
+                title="AVTX Phase 3 Trial Hits Primary Endpoint",
+                url="https://example.com/a",
+            )
+        )
+        rec.record_float(
+            FloatRecord(
+                ticker="AVTX",
+                as_of=date(2026, 4, 26),
+                float_shares=8_500_000,
+                shares_outstanding=12_000_000,
+                source="benzinga",
+            )
+        )
+
+
+async def test_quotes_roundtrip(tmp_path: Path) -> None:
+    await _record_fixture(tmp_path)
+    replay = ReplayProvider(tmp_path, mode=ReplayMode.AS_FAST_AS_POSSIBLE)
+    await replay.connect()
+    out: list[Quote] = [q async for q in replay.subscribe_quotes(["AVTX"])]
+    assert [q.symbol for q in out] == ["AVTX", "AVTX"]
+    assert out[0].bid == Decimal("4.21")
+    assert out[1].ask == Decimal("4.24")
+
+
+async def test_bars_filter_by_timeframe(tmp_path: Path) -> None:
+    await _record_fixture(tmp_path)
+    replay = ReplayProvider(tmp_path)
+    await replay.connect()
+    bars: list[Bar] = [
+        b async for b in replay.subscribe_bars(["AVTX"], Timeframe.M1)
+    ]
+    assert len(bars) == 2
+    bars_d1: list[Bar] = [
+        b async for b in replay.subscribe_bars(["AVTX"], Timeframe.D1)
+    ]
+    assert bars_d1 == []
+
+
+async def test_tape_roundtrip_preserves_side(tmp_path: Path) -> None:
+    await _record_fixture(tmp_path)
+    replay = ReplayProvider(tmp_path)
+    await replay.connect()
+    tapes: list[Tape] = [t async for t in replay.subscribe_tape(["AVTX"])]
+    assert len(tapes) == 1
+    assert tapes[0].side is Side.BUY
+    assert tapes[0].price == Decimal("4.22")
+
+
+async def test_headline_roundtrip(tmp_path: Path) -> None:
+    await _record_fixture(tmp_path)
+    replay = ReplayProvider(tmp_path)
+    await replay.connect()
+    heads: list[Headline] = [
+        h async for h in replay.subscribe_headlines(["AVTX"])
+    ]
+    assert len(heads) == 1
+    assert heads[0].url == "https://example.com/a"
+
+
+async def test_float_roundtrip(tmp_path: Path) -> None:
+    await _record_fixture(tmp_path)
+    replay = ReplayProvider(tmp_path)
+    await replay.connect()
+    rec = await replay.get_float("AVTX", date(2026, 4, 26))
+    assert rec.float_shares == 8_500_000
+
+
+async def test_float_missing_raises(tmp_path: Path) -> None:
+    await _record_fixture(tmp_path)
+    replay = ReplayProvider(tmp_path)
+    await replay.connect()
+    with pytest.raises(MissingRecordingError):
+        await replay.get_float("ZZZZ", date(2026, 4, 26))
+
+
+async def test_historical_bars_window(tmp_path: Path) -> None:
+    await _record_fixture(tmp_path)
+    replay = ReplayProvider(tmp_path)
+    await replay.connect()
+    bars = await replay.historical_bars(
+        "AVTX",
+        start=T0,
+        end=T0 + timedelta(seconds=30),
+        timeframe=Timeframe.M1,
+    )
+    assert len(bars) == 1
+    assert bars[0].ts == T0
+
+
+async def test_realtime_mode_paces_with_virtual_clock(tmp_path: Path) -> None:
+    await _record_fixture(tmp_path)
+    clock = VirtualClock(T0)
+    replay = ReplayProvider(tmp_path, mode=ReplayMode.REALTIME, clock=clock)
+    await replay.connect()
+    real = RealClock()
+    real_t0 = real.monotonic()
+    out = [q async for q in replay.subscribe_quotes(["AVTX"])]
+    real_elapsed = real.monotonic() - real_t0
+    # Two AVTX quotes at offsets 0 and 1 second; virtual clock should
+    # advance by 1s. Real wall time stays small because VirtualClock
+    # short-circuits sleep.
+    assert clock.monotonic() == pytest.approx(1.0, abs=0.01)
+    assert real_elapsed < 0.5
+    assert len(out) == 2
+
+
+async def test_recorder_is_idempotent_on_double_close(tmp_path: Path) -> None:
+    rec = FeedRecorder(tmp_path)
+    rec.record_quote(_quote("AVTX", 0, "1.00", "1.01"))
+    await rec.close()
+    await rec.close()  # must not raise


### PR DESCRIPTION
Closes #2.

Implements the read-side data layer: streaming + historical access for quotes, bars, tape, news, and float — plus the recorder/replay pair that satisfies the phase exit criterion.

> **Exit criterion (issue #2):** "Can replay a historical trading day from disk through the data layer with realistic timing." ✅ — `tests/integration/test_replay_day.py`.

## Summary

- **Provider protocols** for market data, news, and float reference (`data/market_feed.py`, `data/news_feed.py`, `data/float_reference.py`).
- **Recorder + Replay**: `FeedRecorder` writes gzip-compressed JSON-Lines per `(date, event-type)`; `ReplayProvider` reads them and implements all three protocols, with `AS_FAST_AS_POSSIBLE` and `REALTIME` (clock-paced) modes.
- **Reconnect / backfill** wrapper (`data/reconnect.py`): exponential backoff capped at 30s, `FeedGap` callback, bar backfill via `historical_bars`. Home for risk #21.
- **Historical cache**: SQLite (WAL) tables for 30-day relative volume and EMA20/50/200 precompute (`data/cache.py` + `data/historical.py`). Feeds §3.1 scanner filter and §3.3 daily-strength filter.
- **`CachedFloatReference`**: 24h in-memory cache with explicit `invalidate(ticker)` hook for risk #23.
- **Supporting**: `core/clock.py` gains `Clock` protocol + `RealClock` + `VirtualClock`; `core/errors.py` gets the feed-error hierarchy; `indicators/ema.py` gets the TA-Lib-style EMA primitives; `tests/fakes/` provides scripted fakes used across the suite.

## Atom map (matches the planning doc on issue #2)

| # | Deliverable | Files |
|---|-------------|-------|
| 1 | Data package + types | `data/__init__.py`, `data/types.py` |
| 2 | `MarketDataProvider` protocol | `data/market_feed.py` |
| 3 | `NewsProvider` + `HeadlineDeduper` | `data/news_feed.py` |
| 4 | `FloatReferenceProvider` protocol | `data/float_reference.py` |
| 5 | `FeedRecorder` (multi-stream) | `data/recorder.py`, `data/_codec.py` |
| 6 | `ReplayProvider` | `data/providers/replay.py` |
| 7 | Fake providers | `tests/fakes/` |
| 8 | `ReconnectingProvider` | `data/reconnect.py` |
| 9 | Historical volume cache | `data/cache.py`, `data/historical.py` |
| 10 | Daily EMA precompute | `data/historical.py`, `indicators/ema.py` |
| 11 | `CachedFloatReference` | `data/float_reference.py` |
| 15 | End-to-end replay test | `tests/integration/test_replay_day.py` |

**BLOCKED** atoms (vendor-specific, not in this PR):

- Atom 12 — concrete `MarketDataProvider` implementation (waiting on decision **#11**).
- Atom 13 — concrete `NewsProvider` implementation (waiting on decision **#32**).
- Atom 14 — concrete `FloatReferenceProvider` implementation (waiting on decision **#33**).

The protocols and cache layers in this PR are vendor-agnostic; the BLOCKED atoms plug in via `data/providers/` when those decisions land.

## Decisions made (open questions on issue #2)

| Q | Decision |
|---|----------|
| Q4 — 10-sec bars (#14) | Include `S10` in `Timeframe`; providers declare via `supported_timeframes`. |
| Q5 — Cache format | **SQLite** (WAL mode), Decimal stored as string. |
| Q6 — Recording wire format | **gzip-compressed JSON-Lines**, one file per `(UTC-date, event-type)`, schema-versioned envelope. |
| Q7 — Replay timing | Both `AS_FAST_AS_POSSIBLE` and `REALTIME` modes. |
| Q8 — Virtual clock | New `VirtualClock` in `core/clock.py`; injected via `Clock` protocol everywhere. |
| Q9 — Prices | `decimal.Decimal`, tz-aware UTC datetimes. |
| Q12 — News/float in recordings | Yes — `FeedRecorder.record_headline` + `record_float`; `ReplayProvider` exposes `subscribe_headlines` + `get_float`. |

## Verification

```
ruff check src tests       ✓
mypy --strict src tests    ✓  (41 files)
pytest                     ✓  (51 passed)
```

## Test plan

- [ ] CI runs ruff, mypy --strict, and pytest on push.
- [ ] Reviewer confirms `tests/integration/test_replay_day.py::test_replay_full_session_roundtrip` is the canonical exit-criterion check.
- [ ] Reviewer sanity-checks the JSON-Lines schema in `data/_codec.py` (`SCHEMA_VERSION = 1`) — recordings written today must remain readable after future schema bumps.
- [ ] Reviewer reviews the `Clock` injection points to confirm no module reaches for `datetime.now()` or `time.time()` directly.
- [ ] Once decisions #11 / #32 / #33 land, the corresponding `data/providers/<vendor>.py` modules will be added in follow-up PRs and tested against the same conformance bar as the fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)