### PR TITLE
feat(journal): SQLAlchemy storage layer for scanner decisions (#43)

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,44 @@
+; Alembic config for the scanner journal (Phase 2 -- A4 / #43).
+;
+; Default sqlalchemy.url points at a local SQLite file for ad-hoc CLI use
+; (`alembic upgrade head`). Tests bypass this file by passing an existing
+; engine connection through ``Config.attributes['connection']``.
+
+[alembic]
+script_location = src/ross_trading/journal/migrations
+prepend_sys_path = .
+sqlalchemy.url = sqlite:///journal.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ version = "0.0.0"
 description = "Autonomous AI trading agent mimicking Ross Cameron's small-cap momentum process."
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "sqlalchemy>=2",
+    "alembic",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -22,7 +25,7 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.setuptools.package-data]
-ross_trading = ["py.typed"]
+ross_trading = ["py.typed", "journal/migrations/script.py.mako"]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "Autonomous AI trading agent mimicking Ross Cameron's small-cap mo
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "sqlalchemy>=2",
-    "alembic",
+    "sqlalchemy>=2,<3",
+    "alembic>=1.13",
 ]
 
 [project.optional-dependencies]

--- a/src/ross_trading/journal/__init__.py
+++ b/src/ross_trading/journal/__init__.py
@@ -1,0 +1,23 @@
+"""Durable record of agent decisions, backed by SQLAlchemy 2.x + Alembic.
+
+Phase 2 -- Atom A4 (#43). Storage layer for the scanner journal: ``Pick``,
+``WatchlistEntry``, ``ScannerDecision``. The writer (A5 / #44) lands on top
+of :class:`ross_trading.scanner.decisions.DecisionSink`; A6 (#45) and A7
+(#46) read back through this same model surface.
+
+Why SQLAlchemy here when ``data/cache.py`` uses raw ``sqlite3``? The
+inconsistency is intentional and documented at both sites:
+
+* ``data/cache.py`` is a hot-path, append-only analytic cache (daily
+  volumes, EMAs). The schema is small and stable; raw ``sqlite3`` keeps it
+  dependency-light and sub-millisecond.
+* This module is the durable record of agent decisions across versions.
+  The schema *will* evolve (rank weights, new filters, post-hoc
+  enrichment), and the data outlives the agent process. SQLAlchemy 2.x
+  typed ORM + Alembic gives us migration ergonomics today and a Postgres
+  swap option later if we outgrow SQLite.
+
+Do not "harmonize" the two without a concrete need -- the cost
+(complexity, runtime overhead, lost type safety on one side or the other)
+outweighs the win (one fewer dependency surface).
+"""

--- a/src/ross_trading/journal/engine.py
+++ b/src/ross_trading/journal/engine.py
@@ -1,34 +1,39 @@
 """Engine + session factory for the scanner journal.
 
-Configures the SQLite DBAPI for ``BEGIN IMMEDIATE`` semantics and enables
-WAL journaling on every new connection. SQLAlchemy 2.x manages
-transactions itself and overrides the pysqlite driver's
-``isolation_level`` at runtime, so the connect-arg alone is not enough
-to actually emit ``BEGIN IMMEDIATE`` -- a ``begin`` event listener does
-the substantive work; the connect-arg keeps the configuration
-discoverable to tooling that introspects DBAPI args.
+Configures the SQLite DBAPI for ``BEGIN IMMEDIATE`` semantics, enables
+WAL journaling, and turns on foreign-key enforcement on every new
+connection. SQLAlchemy 2.x manages transactions itself and overrides
+the pysqlite driver's ``isolation_level`` at runtime, so the connect-arg
+alone is not enough to actually emit ``BEGIN IMMEDIATE`` -- a ``begin``
+event listener does the substantive work; the connect-arg keeps the
+configuration discoverable to tooling that introspects DBAPI args.
+
+SQLite ships with foreign-key enforcement disabled by default, so a
+``connect`` event listener issues ``PRAGMA foreign_keys = ON`` per
+connection (alongside ``PRAGMA journal_mode=WAL``). Without it,
+``ScannerDecision.pick_id`` and ``WatchlistEntry.pick_id`` would happily
+accept dangling references.
 
 In-memory SQLite (``sqlite://`` or ``sqlite:///:memory:``) is detected
-and switched to ``StaticPool`` so a single connection is shared across
-the engine's lifetime. Without this, separate connections each see an
-independent in-memory database, which breaks tests that create the
-schema once and then query through the ORM.
+via :func:`sqlalchemy.make_url` and switched to ``StaticPool`` so a
+single connection is shared across the engine's lifetime. Without this,
+separate connections each see an independent in-memory database, which
+breaks tests that create the schema once and then query through the
+ORM.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final
 
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, make_url
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
 
-JOURNAL_CONNECT_ARGS: Final[dict[str, str]] = {"isolation_level": "IMMEDIATE"}
-
-_IN_MEMORY_URLS: Final[frozenset[str]] = frozenset({"sqlite://", "sqlite:///:memory:"})
+JOURNAL_CONNECT_ARGS: Final[dict[str, Any]] = {"isolation_level": "IMMEDIATE"}
 
 
 def create_journal_engine(
@@ -37,7 +42,12 @@ def create_journal_engine(
     echo: bool = False,
 ) -> Engine:
     """Create a journal :class:`Engine` with WAL + IMMEDIATE configured."""
-    is_memory = url in _IN_MEMORY_URLS
+    parsed = make_url(url)
+    is_memory = parsed.get_backend_name() == "sqlite" and parsed.database in (
+        None,
+        "",
+        ":memory:",
+    )
     connect_args: dict[str, Any] = dict(JOURNAL_CONNECT_ARGS)
     kwargs: dict[str, Any] = {"echo": echo}
     if is_memory:
@@ -48,13 +58,14 @@ def create_journal_engine(
     engine = create_engine(url, **kwargs)
 
     @event.listens_for(engine, "connect")
-    def _enable_wal(
+    def _apply_pragmas(
         dbapi_connection: Any,
         _connection_record: Any,
     ) -> None:
         cursor = dbapi_connection.cursor()
         try:
             cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA foreign_keys = ON")
         finally:
             cursor.close()
 

--- a/src/ross_trading/journal/engine.py
+++ b/src/ross_trading/journal/engine.py
@@ -1,0 +1,70 @@
+"""Engine + session factory for the scanner journal.
+
+Configures the SQLite DBAPI for ``BEGIN IMMEDIATE`` semantics and enables
+WAL journaling on every new connection. SQLAlchemy 2.x manages
+transactions itself and overrides the pysqlite driver's
+``isolation_level`` at runtime, so the connect-arg alone is not enough
+to actually emit ``BEGIN IMMEDIATE`` -- a ``begin`` event listener does
+the substantive work; the connect-arg keeps the configuration
+discoverable to tooling that introspects DBAPI args.
+
+In-memory SQLite (``sqlite://`` or ``sqlite:///:memory:``) is detected
+and switched to ``StaticPool`` so a single connection is shared across
+the engine's lifetime. Without this, separate connections each see an
+independent in-memory database, which breaks tests that create the
+schema once and then query through the ORM.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+
+JOURNAL_CONNECT_ARGS: Final[dict[str, str]] = {"isolation_level": "IMMEDIATE"}
+
+_IN_MEMORY_URLS: Final[frozenset[str]] = frozenset({"sqlite://", "sqlite:///:memory:"})
+
+
+def create_journal_engine(
+    url: str = "sqlite:///:memory:",
+    *,
+    echo: bool = False,
+) -> Engine:
+    """Create a journal :class:`Engine` with WAL + IMMEDIATE configured."""
+    is_memory = url in _IN_MEMORY_URLS
+    connect_args: dict[str, Any] = dict(JOURNAL_CONNECT_ARGS)
+    kwargs: dict[str, Any] = {"echo": echo}
+    if is_memory:
+        kwargs["poolclass"] = StaticPool
+        connect_args["check_same_thread"] = False
+    kwargs["connect_args"] = connect_args
+
+    engine = create_engine(url, **kwargs)
+
+    @event.listens_for(engine, "connect")
+    def _enable_wal(
+        dbapi_connection: Any,
+        _connection_record: Any,
+    ) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+        finally:
+            cursor.close()
+
+    @event.listens_for(engine, "begin")
+    def _begin_immediate(conn: Any) -> None:
+        conn.exec_driver_sql("BEGIN IMMEDIATE")
+
+    return engine
+
+
+def create_session_factory(engine: Engine) -> sessionmaker[Session]:
+    """Bind a default :class:`sessionmaker` to ``engine``."""
+    return sessionmaker(bind=engine, expire_on_commit=False)

--- a/src/ross_trading/journal/migrations/env.py
+++ b/src/ross_trading/journal/migrations/env.py
@@ -1,0 +1,78 @@
+"""Alembic environment for the scanner journal.
+
+Configured with ``render_as_batch=True`` because SQLite cannot perform
+arbitrary ``ALTER TABLE`` statements; Alembic's batch-mode rewrites the
+operation as ``CREATE TABLE new + COPY + DROP old + RENAME``. We keep
+batch mode on for Postgres too -- it is a no-op there but keeps every
+revision portable.
+
+Tests pass an existing ``Connection`` via
+``Config.attributes['connection']`` so migrations run against the
+session-scoped in-memory engine. The file-config path is only used by
+the CLI (``alembic upgrade head``).
+"""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from ross_trading.journal.models import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Render SQL to stdout without a live DBAPI connection."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        render_as_batch=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations against a live engine or an injected connection."""
+    injected = config.attributes.get("connection")
+    if injected is not None:
+        context.configure(
+            connection=injected,
+            target_metadata=target_metadata,
+            render_as_batch=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+        return
+
+    section = config.get_section(config.config_ini_section, {})
+    connectable = engine_from_config(
+        section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/src/ross_trading/journal/migrations/script.py.mako
+++ b/src/ross_trading/journal/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/src/ross_trading/journal/migrations/script.py.mako
+++ b/src/ross_trading/journal/migrations/script.py.mako
@@ -7,7 +7,7 @@ Create Date: ${create_date}
 """
 from __future__ import annotations
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 import sqlalchemy as sa
@@ -15,9 +15,9 @@ ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision: str = ${repr(up_revision)}
-down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
-branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
-depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+down_revision: str | Sequence[str] | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
 
 
 def upgrade() -> None:

--- a/src/ross_trading/journal/migrations/versions/0001_initial_schema.py
+++ b/src/ross_trading/journal/migrations/versions/0001_initial_schema.py
@@ -1,0 +1,118 @@
+"""initial scanner-journal schema: picks, watchlist_entries, scanner_decisions.
+
+Revision ID: 0001_initial
+Revises:
+Create Date: 2026-05-02 00:00:00
+
+Creates all three journal tables with the four-value ``DecisionKind`` enum
+and the seven-value ``RejectionReason`` enum already populated, even
+though A3 only emits three of the kinds today and the rejection enum is
+unused until #51. Landing the full vocabulary now keeps #51 a wiring-only
+change.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+_DECISION_KINDS = ("picked", "stale_feed", "feed_gap", "rejected")
+_REJECTION_REASONS = (
+    "no_snapshot",
+    "missing_baseline",
+    "missing_float",
+    "rel_volume",
+    "pct_change",
+    "price_band",
+    "float_size",
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "picks",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("ticker", sa.String(), nullable=False),
+        sa.Column("ts", sa.String(), nullable=False),
+        sa.Column("rel_volume", sa.String(), nullable=False),
+        sa.Column("pct_change", sa.String(), nullable=False),
+        sa.Column("price", sa.String(), nullable=False),
+        sa.Column("float_shares", sa.Integer(), nullable=False),
+        sa.Column("news_present", sa.Boolean(), nullable=False),
+        sa.Column("headline_count", sa.Integer(), nullable=False),
+        sa.Column("rank", sa.Integer(), nullable=False),
+    )
+    op.create_index("ix_picks_ticker_ts", "picks", ["ticker", "ts"])
+
+    op.create_table(
+        "watchlist_entries",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("ticker", sa.String(), nullable=False),
+        sa.Column(
+            "pick_id",
+            sa.Integer(),
+            sa.ForeignKey("picks.id"),
+            nullable=False,
+        ),
+        sa.Column("added_at", sa.String(), nullable=False),
+        sa.Column("removed_at", sa.String(), nullable=True),
+    )
+    op.create_index(
+        "ix_watchlist_active_by_ticker",
+        "watchlist_entries",
+        ["ticker"],
+        sqlite_where=sa.text("removed_at IS NULL"),
+        postgresql_where=sa.text("removed_at IS NULL"),
+    )
+
+    op.create_table(
+        "scanner_decisions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "kind",
+            sa.Enum(*_DECISION_KINDS, name="decision_kind"),
+            nullable=False,
+        ),
+        sa.Column("decision_ts", sa.String(), nullable=False),
+        sa.Column("ticker", sa.String(), nullable=True),
+        sa.Column(
+            "pick_id",
+            sa.Integer(),
+            sa.ForeignKey("picks.id"),
+            nullable=True,
+        ),
+        sa.Column("reason", sa.String(), nullable=True),
+        sa.Column("gap_start", sa.String(), nullable=True),
+        sa.Column("gap_end", sa.String(), nullable=True),
+        sa.Column(
+            "rejection_reason",
+            sa.Enum(*_REJECTION_REASONS, name="rejection_reason"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_scanner_decisions_decision_ts",
+        "scanner_decisions",
+        ["decision_ts"],
+    )
+    op.create_index(
+        "ix_scanner_decisions_kind_ts",
+        "scanner_decisions",
+        ["kind", "decision_ts"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_scanner_decisions_kind_ts", table_name="scanner_decisions")
+    op.drop_index("ix_scanner_decisions_decision_ts", table_name="scanner_decisions")
+    op.drop_table("scanner_decisions")
+    op.drop_index("ix_watchlist_active_by_ticker", table_name="watchlist_entries")
+    op.drop_table("watchlist_entries")
+    op.drop_index("ix_picks_ticker_ts", table_name="picks")
+    op.drop_table("picks")

--- a/src/ross_trading/journal/models.py
+++ b/src/ross_trading/journal/models.py
@@ -1,0 +1,164 @@
+"""SQLAlchemy 2.x typed ORM models for the scanner journal.
+
+Mirrors :class:`ross_trading.scanner.types.ScannerPick` and
+:class:`ross_trading.scanner.decisions.ScannerDecision`. ``WatchlistEntry``
+captures open-ended watchlist membership for a Pick (added_at /
+removed_at), so survivorship is a temporal fact rather than a per-tick
+snapshot.
+
+Two enum vocabularies are pinned at the schema level today even though
+A3 only emits a subset:
+
+* :class:`DecisionKind` -- four values. ``rejected`` is reserved for #51
+  (rejected-decision wiring); A3 only emits ``picked`` / ``stale_feed`` /
+  ``feed_gap``. Landing it now makes #51 a wiring-only change.
+* :class:`RejectionReason` -- seven values. The order matches the
+  AND-chain in :func:`ross_trading.scanner.scanner.Scanner.scan` so the
+  enum order itself encodes "first failing filter" priority. The literal
+  values are the contract referenced by #51 and must not be renamed
+  without a matching migration.
+"""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime  # noqa: TC003 -- SA 2.x evals Mapped[datetime] at runtime
+from decimal import Decimal  # noqa: TC003 -- SA 2.x evals Mapped[Decimal] at runtime
+
+from sqlalchemy import (
+    Boolean,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    text,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from ross_trading.journal.types import DecimalText, TzAwareUTC
+
+
+class Base(DeclarativeBase):
+    """Declarative base for all journal models."""
+
+
+class DecisionKind(enum.StrEnum):
+    """Kind of :class:`ScannerDecision` row.
+
+    ``REJECTED`` is reserved for #51 -- A3 only emits the other three.
+    """
+
+    PICKED = "picked"
+    STALE_FEED = "stale_feed"
+    FEED_GAP = "feed_gap"
+    REJECTED = "rejected"
+
+
+class RejectionReason(enum.StrEnum):
+    """First-failing-filter reason for a ``REJECTED`` decision.
+
+    Order matches the AND-chain in
+    :func:`ross_trading.scanner.scanner.Scanner.scan` (snapshot presence
+    -> baseline -> float record -> rel_volume -> pct_change ->
+    price_band -> float_size). Literal values are the contract referenced
+    by #51 and must not be renamed without a matching migration.
+    """
+
+    NO_SNAPSHOT = "no_snapshot"
+    MISSING_BASELINE = "missing_baseline"
+    MISSING_FLOAT = "missing_float"
+    REL_VOLUME = "rel_volume"
+    PCT_CHANGE = "pct_change"
+    PRICE_BAND = "price_band"
+    FLOAT_SIZE = "float_size"
+
+
+class Pick(Base):
+    """A symbol that passed the scanner's hard filters (ranked output).
+
+    Mirrors :class:`ross_trading.scanner.types.ScannerPick`.
+    ``headline_count`` is an explicit ``Integer`` column -- first-class,
+    not derived -- so Phase 3 retrospectives can correlate outcome
+    quality with headline volume.
+    """
+
+    __tablename__ = "picks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    ticker: Mapped[str] = mapped_column(String, nullable=False)
+    ts: Mapped[datetime] = mapped_column(TzAwareUTC, nullable=False)
+    rel_volume: Mapped[Decimal] = mapped_column(DecimalText, nullable=False)
+    pct_change: Mapped[Decimal] = mapped_column(DecimalText, nullable=False)
+    price: Mapped[Decimal] = mapped_column(DecimalText, nullable=False)
+    float_shares: Mapped[int] = mapped_column(Integer, nullable=False)
+    news_present: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    headline_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    rank: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    __table_args__ = (Index("ix_picks_ticker_ts", "ticker", "ts"),)
+
+
+class WatchlistEntry(Base):
+    """Open-ended watchlist membership for a :class:`Pick`.
+
+    ``added_at`` marks promotion onto the watchlist; ``removed_at`` is
+    ``None`` while membership is active. The partial index on
+    ``(ticker)`` filtered by ``removed_at IS NULL`` keeps "currently on
+    watchlist" lookups (A7 / #46) cheap.
+    """
+
+    __tablename__ = "watchlist_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    ticker: Mapped[str] = mapped_column(String, nullable=False)
+    pick_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("picks.id"), nullable=False,
+    )
+    added_at: Mapped[datetime] = mapped_column(TzAwareUTC, nullable=False)
+    removed_at: Mapped[datetime | None] = mapped_column(TzAwareUTC, nullable=True)
+
+    pick: Mapped[Pick] = relationship(Pick)
+
+    __table_args__ = (
+        Index(
+            "ix_watchlist_active_by_ticker",
+            "ticker",
+            sqlite_where=text("removed_at IS NULL"),
+            postgresql_where=text("removed_at IS NULL"),
+        ),
+    )
+
+
+class ScannerDecision(Base):
+    """One row per tick outcome from the scanner loop.
+
+    Mirrors :class:`ross_trading.scanner.decisions.ScannerDecision`.
+    ``pick_id`` is set only when ``kind=PICKED``; ``rejection_reason`` is
+    set only when ``kind=REJECTED``.
+    """
+
+    __tablename__ = "scanner_decisions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    kind: Mapped[DecisionKind] = mapped_column(
+        Enum(DecisionKind, name="decision_kind"), nullable=False,
+    )
+    decision_ts: Mapped[datetime] = mapped_column(TzAwareUTC, nullable=False)
+    ticker: Mapped[str | None] = mapped_column(String, nullable=True)
+    pick_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("picks.id"), nullable=True,
+    )
+    reason: Mapped[str | None] = mapped_column(String, nullable=True)
+    gap_start: Mapped[datetime | None] = mapped_column(TzAwareUTC, nullable=True)
+    gap_end: Mapped[datetime | None] = mapped_column(TzAwareUTC, nullable=True)
+    rejection_reason: Mapped[RejectionReason | None] = mapped_column(
+        Enum(RejectionReason, name="rejection_reason"), nullable=True,
+    )
+
+    pick: Mapped[Pick | None] = relationship(Pick)
+
+    __table_args__ = (
+        Index("ix_scanner_decisions_decision_ts", "decision_ts"),
+        Index("ix_scanner_decisions_kind_ts", "kind", "decision_ts"),
+    )

--- a/src/ross_trading/journal/models.py
+++ b/src/ross_trading/journal/models.py
@@ -142,7 +142,12 @@ class ScannerDecision(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     kind: Mapped[DecisionKind] = mapped_column(
-        Enum(DecisionKind, name="decision_kind"), nullable=False,
+        Enum(
+            DecisionKind,
+            name="decision_kind",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        nullable=False,
     )
     decision_ts: Mapped[datetime] = mapped_column(TzAwareUTC, nullable=False)
     ticker: Mapped[str | None] = mapped_column(String, nullable=True)
@@ -153,7 +158,12 @@ class ScannerDecision(Base):
     gap_start: Mapped[datetime | None] = mapped_column(TzAwareUTC, nullable=True)
     gap_end: Mapped[datetime | None] = mapped_column(TzAwareUTC, nullable=True)
     rejection_reason: Mapped[RejectionReason | None] = mapped_column(
-        Enum(RejectionReason, name="rejection_reason"), nullable=True,
+        Enum(
+            RejectionReason,
+            name="rejection_reason",
+            values_callable=lambda obj: [e.value for e in obj],
+        ),
+        nullable=True,
     )
 
     pick: Mapped[Pick | None] = relationship(Pick)

--- a/src/ross_trading/journal/types.py
+++ b/src/ross_trading/journal/types.py
@@ -1,0 +1,87 @@
+"""Reusable SQLAlchemy ``TypeDecorator`` classes for the journal.
+
+Two type decorators that mirror the precision/timezone rigor used in
+``data/cache.py``:
+
+* :class:`TzAwareUTC` -- datetime column that requires tz-aware values on
+  bind, persists as ISO-8601 UTC TEXT, and re-attaches UTC on load.
+  SQLite has no native tz type and SQLAlchemy ``DateTime(timezone=True)``
+  is a no-op there -- silently stripping tzinfo would break replay
+  determinism and the tz-aware invariants enforced upstream
+  (e.g. :class:`ross_trading.scanner.decisions.ScannerDecision`).
+* :class:`DecimalText` -- ``Decimal`` column persisted as TEXT to preserve
+  precision. SQLAlchemy ``Numeric`` degrades to FLOAT on SQLite and
+  silently loses precision on values like ``rel_volume`` and
+  ``pct_change``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import String
+from sqlalchemy.types import TypeDecorator
+
+
+class TzAwareUTC(TypeDecorator[datetime]):
+    """Datetime column round-tripped as ISO-8601 UTC TEXT.
+
+    Naive datetimes are rejected on bind with a clear ``ValueError``.
+    """
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(
+        self,
+        value: datetime | None,
+        dialect: Any,
+    ) -> str | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            msg = "TzAwareUTC requires a tz-aware datetime; got naive"
+            raise ValueError(msg)
+        return value.astimezone(UTC).isoformat()
+
+    def process_result_value(
+        self,
+        value: str | None,
+        dialect: Any,
+    ) -> datetime | None:
+        if value is None:
+            return None
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+
+
+class DecimalText(TypeDecorator[Decimal]):
+    """``Decimal`` column persisted as TEXT to preserve precision."""
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(
+        self,
+        value: Decimal | None,
+        dialect: Any,
+    ) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, Decimal):
+            msg = f"DecimalText requires Decimal; got {type(value).__name__}"
+            raise TypeError(msg)
+        return str(value)
+
+    def process_result_value(
+        self,
+        value: str | None,
+        dialect: Any,
+    ) -> Decimal | None:
+        if value is None:
+            return None
+        return Decimal(value)

--- a/tests/integration/test_journal_migrations.py
+++ b/tests/integration/test_journal_migrations.py
@@ -103,8 +103,18 @@ def test_orm_inserts_persist_lowercase_enum_values_against_migration(
     raw column values back through ``exec_driver_sql`` to confirm the
     lowercase ``.value`` strings -- not the uppercase ``.name``s -- hit
     the database.
+
+    Wraps the inserts in a SAVEPOINT that is rolled back at the end so
+    the session-scoped ``migrated_engine`` fixture does not accumulate
+    state across tests. Raw reads happen *inside* the savepoint, before
+    rollback.
     """
-    with Session(migrated_engine) as session:
+    with (
+        migrated_engine.connect() as outer_conn,
+        outer_conn.begin(),
+        Session(bind=outer_conn) as session,
+        session.begin_nested() as nested,
+    ):
         picked = ScannerDecision(
             kind=DecisionKind.PICKED,
             decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
@@ -117,24 +127,32 @@ def test_orm_inserts_persist_lowercase_enum_values_against_migration(
             rejection_reason=RejectionReason.REL_VOLUME,
         )
         session.add_all([picked, rejected])
-        session.commit()
+        session.flush()
         picked_id = picked.id
         rejected_id = rejected.id
 
-    with migrated_engine.connect() as conn:
-        picked_kind = conn.exec_driver_sql(
+        picked_kind = outer_conn.exec_driver_sql(
             "SELECT kind FROM scanner_decisions WHERE id = ?",
             (picked_id,),
         ).scalar_one()
-        rejected_kind = conn.exec_driver_sql(
+        rejected_kind = outer_conn.exec_driver_sql(
             "SELECT kind FROM scanner_decisions WHERE id = ?",
             (rejected_id,),
         ).scalar_one()
-        rejected_reason = conn.exec_driver_sql(
+        rejected_reason = outer_conn.exec_driver_sql(
             "SELECT rejection_reason FROM scanner_decisions WHERE id = ?",
             (rejected_id,),
         ).scalar_one()
 
+        nested.rollback()
+
     assert picked_kind == "picked"
     assert rejected_kind == "rejected"
     assert rejected_reason == "rel_volume"
+
+    # Cleanup invariant: nothing leaked into the session-scoped engine.
+    with migrated_engine.connect() as conn:
+        count = conn.exec_driver_sql(
+            "SELECT COUNT(*) FROM scanner_decisions",
+        ).scalar_one()
+    assert count == 0

--- a/tests/integration/test_journal_migrations.py
+++ b/tests/integration/test_journal_migrations.py
@@ -1,0 +1,80 @@
+"""Atom A4 (#43) -- alembic upgrade head + downgrade base round trip.
+
+Runs the migration tree against an in-memory SQLite engine via a shared
+connection (passed through ``Config.attributes['connection']``) so the
+session-scoped fixture matches the ``HistoricalCache`` testing pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import inspect
+
+from ross_trading.journal.engine import create_journal_engine
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy.engine import Connection, Engine
+
+pytestmark = pytest.mark.integration
+
+_MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "ross_trading"
+    / "journal"
+    / "migrations"
+)
+_EXPECTED_TABLES = frozenset({"picks", "watchlist_entries", "scanner_decisions"})
+
+
+def _alembic_config(connection: Connection) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    cfg.attributes["connection"] = connection
+    return cfg
+
+
+@pytest.fixture(scope="session")
+def migrated_engine() -> Iterator[Engine]:
+    """Engine with the journal schema applied via ``alembic upgrade head``.
+
+    Session-scoped: the migration runs once and downstream tests reuse the
+    schema.
+    """
+    engine = create_journal_engine("sqlite://")
+    with engine.begin() as conn:
+        command.upgrade(_alembic_config(conn), "head")
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def test_upgrade_head_creates_expected_tables(migrated_engine: Engine) -> None:
+    with migrated_engine.connect() as conn:
+        names = set(inspect(conn).get_table_names())
+    assert names >= _EXPECTED_TABLES
+    assert "alembic_version" in names
+
+
+def test_upgrade_head_then_downgrade_base() -> None:
+    engine = create_journal_engine("sqlite://")
+    try:
+        with engine.begin() as conn:
+            cfg = _alembic_config(conn)
+            command.upgrade(cfg, "head")
+            after_upgrade = set(inspect(conn).get_table_names())
+            assert after_upgrade >= _EXPECTED_TABLES
+
+            command.downgrade(cfg, "base")
+            after_downgrade = set(inspect(conn).get_table_names())
+            assert _EXPECTED_TABLES.isdisjoint(after_downgrade)
+    finally:
+        engine.dispose()

--- a/tests/integration/test_journal_migrations.py
+++ b/tests/integration/test_journal_migrations.py
@@ -7,6 +7,7 @@ session-scoped fixture matches the ``HistoricalCache`` testing pattern.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,8 +15,14 @@ import pytest
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import inspect
+from sqlalchemy.orm import Session
 
 from ross_trading.journal.engine import create_journal_engine
+from ross_trading.journal.models import (
+    DecisionKind,
+    RejectionReason,
+    ScannerDecision,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -78,3 +85,56 @@ def test_upgrade_head_then_downgrade_base() -> None:
             assert _EXPECTED_TABLES.isdisjoint(after_downgrade)
     finally:
         engine.dispose()
+
+
+def test_orm_inserts_persist_lowercase_enum_values_against_migration(
+    migrated_engine: Engine,
+) -> None:
+    """Regression: ORM must write enum ``.value`` strings, not ``.name``.
+
+    The migration declares ``decision_kind`` and ``rejection_reason`` as
+    lowercase literals (``picked``, ``rel_volume`` ...). Without
+    ``values_callable`` on the model's ``Enum`` columns SA persists the
+    member name (``PICKED``), which the migration's CHECK constraint
+    rejects at runtime.
+
+    Inserts a ``PICKED`` row and a ``REJECTED`` + ``REL_VOLUME`` row via
+    an ORM session bound to the alembic-migrated engine, then reads the
+    raw column values back through ``exec_driver_sql`` to confirm the
+    lowercase ``.value`` strings -- not the uppercase ``.name``s -- hit
+    the database.
+    """
+    with Session(migrated_engine) as session:
+        picked = ScannerDecision(
+            kind=DecisionKind.PICKED,
+            decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+            ticker="ABCD",
+        )
+        rejected = ScannerDecision(
+            kind=DecisionKind.REJECTED,
+            decision_ts=datetime(2026, 5, 2, 14, 31, tzinfo=UTC),
+            ticker="WXYZ",
+            rejection_reason=RejectionReason.REL_VOLUME,
+        )
+        session.add_all([picked, rejected])
+        session.commit()
+        picked_id = picked.id
+        rejected_id = rejected.id
+
+    with migrated_engine.connect() as conn:
+        picked_kind = conn.exec_driver_sql(
+            "SELECT kind FROM scanner_decisions WHERE id = ?",
+            (picked_id,),
+        ).scalar_one()
+        rejected_kind = conn.exec_driver_sql(
+            "SELECT kind FROM scanner_decisions WHERE id = ?",
+            (rejected_id,),
+        ).scalar_one()
+        rejected_reason = conn.exec_driver_sql(
+            "SELECT rejection_reason FROM scanner_decisions WHERE id = ?",
+            (rejected_id,),
+        ).scalar_one()
+
+    assert picked_kind == "picked"
+    assert rejected_kind == "rejected"
+    assert rejected_reason == "rel_volume"

--- a/tests/unit/test_journal_engine.py
+++ b/tests/unit/test_journal_engine.py
@@ -1,0 +1,65 @@
+"""Atom A4 (#43) -- journal engine WAL + IMMEDIATE configuration.
+
+Acceptance criterion: ``journal_mode=WAL`` and ``isolation_level=IMMEDIATE``
+verified on engine create. WAL is observable on a file-based engine via
+``PRAGMA journal_mode``; IMMEDIATE is observable via the begin-event
+listener that issues ``BEGIN IMMEDIATE`` (SQLAlchemy 2.x overrides the
+pysqlite driver's ``isolation_level`` at runtime, so the connect-arg
+alone is not enough -- the listener does the substantive work).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import event
+
+from ross_trading.journal.engine import (
+    JOURNAL_CONNECT_ARGS,
+    create_journal_engine,
+)
+
+
+def test_connect_args_pin_immediate() -> None:
+    assert JOURNAL_CONNECT_ARGS == {"isolation_level": "IMMEDIATE"}
+
+
+def test_journal_mode_is_wal_on_file_engine(tmp_path: Any) -> None:
+    """``PRAGMA journal_mode=WAL`` only takes effect on file-backed DBs;
+    in-memory remains 'memory'.
+    """
+    db_path = tmp_path / "journal.db"
+    engine = create_journal_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.connect() as conn:
+            mode = conn.exec_driver_sql("PRAGMA journal_mode").scalar()
+        assert isinstance(mode, str)
+        assert mode.lower() == "wal"
+    finally:
+        engine.dispose()
+
+
+def test_begin_emits_immediate() -> None:
+    """The begin-event listener issues ``BEGIN IMMEDIATE`` -- captured via
+    ``before_cursor_execute``.
+    """
+    engine = create_journal_engine("sqlite://")
+    statements: list[str] = []
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _capture(  # type: ignore[no-untyped-def]
+        _conn,
+        _cursor,
+        statement,
+        _params,
+        _context,
+        _executemany,
+    ) -> None:
+        statements.append(statement.strip().upper())
+
+    try:
+        with engine.begin() as conn:
+            conn.exec_driver_sql("SELECT 1")
+        assert "BEGIN IMMEDIATE" in statements
+    finally:
+        engine.dispose()

--- a/tests/unit/test_journal_engine.py
+++ b/tests/unit/test_journal_engine.py
@@ -10,14 +10,19 @@ alone is not enough -- the listener does the substantive work).
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
+import pytest
 from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from ross_trading.journal.engine import (
     JOURNAL_CONNECT_ARGS,
     create_journal_engine,
 )
+from ross_trading.journal.models import Base, WatchlistEntry
 
 
 def test_connect_args_pin_immediate() -> None:
@@ -61,5 +66,39 @@ def test_begin_emits_immediate() -> None:
         with engine.begin() as conn:
             conn.exec_driver_sql("SELECT 1")
         assert "BEGIN IMMEDIATE" in statements
+    finally:
+        engine.dispose()
+
+
+def test_foreign_keys_pragma_enabled() -> None:
+    """``PRAGMA foreign_keys = ON`` is set on every new connection."""
+    engine = create_journal_engine("sqlite://")
+    try:
+        with engine.connect() as conn:
+            value = conn.exec_driver_sql("PRAGMA foreign_keys").scalar()
+        assert value == 1
+    finally:
+        engine.dispose()
+
+
+def test_foreign_keys_enforced_rejects_dangling_pick_id() -> None:
+    """The pragma is actually in effect: a dangling FK insert raises.
+
+    Without ``PRAGMA foreign_keys = ON`` SQLite would accept a
+    ``WatchlistEntry.pick_id`` referencing a non-existent ``picks.id`` row
+    silently. With the pragma on, the flush raises ``IntegrityError``.
+    """
+    engine = create_journal_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            entry = WatchlistEntry(
+                ticker="ABCD",
+                pick_id=999_999,  # no such Pick
+                added_at=datetime(2026, 5, 2, 14, 31, tzinfo=UTC),
+            )
+            session.add(entry)
+            with pytest.raises(IntegrityError):
+                session.flush()
     finally:
         engine.dispose()

--- a/tests/unit/test_journal_models.py
+++ b/tests/unit/test_journal_models.py
@@ -107,6 +107,15 @@ def test_pick_rejects_naive_datetime(session: Session) -> None:
         session.flush()
 
 
+def test_pick_rejects_non_decimal_price(session: Session) -> None:
+    """``DecimalText`` refuses to silently coerce ``float`` to ``Decimal``."""
+    pick = _make_pick()
+    pick.price = 3.42  # type: ignore[assignment]  # float, not Decimal
+    session.add(pick)
+    with pytest.raises(StatementError, match="DecimalText requires Decimal"):
+        session.flush()
+
+
 def test_watchlist_entry_open_membership(session: Session) -> None:
     pick = _make_pick()
     session.add(pick)

--- a/tests/unit/test_journal_models.py
+++ b/tests/unit/test_journal_models.py
@@ -1,0 +1,290 @@
+"""Atom A4 (#43) -- round-trip every journal model against in-memory SQLite."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import StatementError
+from sqlalchemy.orm import Session
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from ross_trading.journal.engine import create_journal_engine
+from ross_trading.journal.models import (
+    Base,
+    DecisionKind,
+    Pick,
+    RejectionReason,
+    ScannerDecision,
+    WatchlistEntry,
+)
+
+
+@pytest.fixture
+def session() -> Iterator[Session]:
+    engine = create_journal_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _make_pick(
+    *,
+    ticker: str = "ABCD",
+    rank: int = 1,
+    headline_count: int = 4,
+) -> Pick:
+    return Pick(
+        ticker=ticker,
+        ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        rel_volume=Decimal("12.5"),
+        pct_change=Decimal("18.75"),
+        price=Decimal("3.42"),
+        float_shares=8_500_000,
+        news_present=True,
+        headline_count=headline_count,
+        rank=rank,
+    )
+
+
+def test_pick_round_trip(session: Session) -> None:
+    pick = _make_pick()
+    session.add(pick)
+    session.commit()
+
+    fetched = session.get(Pick, pick.id)
+    assert fetched is not None
+    assert fetched.ticker == "ABCD"
+    assert fetched.ts == datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    assert fetched.rel_volume == Decimal("12.5")
+    assert fetched.pct_change == Decimal("18.75")
+    assert fetched.price == Decimal("3.42")
+    assert fetched.float_shares == 8_500_000
+    assert fetched.news_present is True
+    assert fetched.headline_count == 4
+    assert fetched.rank == 1
+
+
+def test_pick_preserves_decimal_precision(session: Session) -> None:
+    """SQLAlchemy ``Numeric`` would degrade these to FLOAT on SQLite."""
+    pick = _make_pick()
+    pick.rel_volume = Decimal("12.123456789012345678")
+    pick.pct_change = Decimal("0.000000000000000001")
+    session.add(pick)
+    session.commit()
+
+    fetched = session.get(Pick, pick.id)
+    assert fetched is not None
+    assert fetched.rel_volume == Decimal("12.123456789012345678")
+    assert fetched.pct_change == Decimal("0.000000000000000001")
+
+
+def test_pick_normalizes_non_utc_tz_to_utc(session: Session) -> None:
+    """Non-UTC tz inputs are stored as UTC and load back as UTC."""
+    et = timezone(timedelta(hours=-4))
+    pick = _make_pick()
+    pick.ts = datetime(2026, 5, 2, 10, 30, tzinfo=et)
+    session.add(pick)
+    session.commit()
+
+    fetched = session.get(Pick, pick.id)
+    assert fetched is not None
+    assert fetched.ts == datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    assert fetched.ts.tzinfo == UTC
+
+
+def test_pick_rejects_naive_datetime(session: Session) -> None:
+    pick = _make_pick()
+    pick.ts = datetime(2026, 5, 2, 14, 30)  # naive
+    session.add(pick)
+    with pytest.raises(StatementError, match="tz-aware"):
+        session.flush()
+
+
+def test_watchlist_entry_open_membership(session: Session) -> None:
+    pick = _make_pick()
+    session.add(pick)
+    session.flush()
+
+    entry = WatchlistEntry(
+        ticker="ABCD",
+        pick_id=pick.id,
+        added_at=datetime(2026, 5, 2, 14, 31, tzinfo=UTC),
+    )
+    session.add(entry)
+    session.commit()
+
+    fetched = session.get(WatchlistEntry, entry.id)
+    assert fetched is not None
+    assert fetched.ticker == "ABCD"
+    assert fetched.pick_id == pick.id
+    assert fetched.added_at == datetime(2026, 5, 2, 14, 31, tzinfo=UTC)
+    assert fetched.removed_at is None
+    assert fetched.pick.id == pick.id
+
+
+def test_watchlist_entry_closed_membership(session: Session) -> None:
+    pick = _make_pick()
+    session.add(pick)
+    session.flush()
+
+    entry = WatchlistEntry(
+        ticker="ABCD",
+        pick_id=pick.id,
+        added_at=datetime(2026, 5, 2, 14, 31, tzinfo=UTC),
+        removed_at=datetime(2026, 5, 2, 15, 0, tzinfo=UTC),
+    )
+    session.add(entry)
+    session.commit()
+
+    fetched = session.get(WatchlistEntry, entry.id)
+    assert fetched is not None
+    assert fetched.removed_at == datetime(2026, 5, 2, 15, 0, tzinfo=UTC)
+
+
+def test_active_watchlist_partial_index_query(session: Session) -> None:
+    """The lookup A7 (#46) will run -- "ABCD currently on the watchlist?"."""
+    pick = _make_pick()
+    session.add(pick)
+    session.flush()
+
+    closed = WatchlistEntry(
+        ticker="ABCD",
+        pick_id=pick.id,
+        added_at=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        removed_at=datetime(2026, 5, 2, 14, 45, tzinfo=UTC),
+    )
+    open_ = WatchlistEntry(
+        ticker="ABCD",
+        pick_id=pick.id,
+        added_at=datetime(2026, 5, 2, 15, 0, tzinfo=UTC),
+    )
+    session.add_all([closed, open_])
+    session.commit()
+
+    active = session.scalars(
+        select(WatchlistEntry).where(
+            WatchlistEntry.ticker == "ABCD",
+            WatchlistEntry.removed_at.is_(None),
+        ),
+    ).all()
+    assert len(active) == 1
+    assert active[0].id == open_.id
+
+
+def test_decision_picked_round_trip(session: Session) -> None:
+    pick = _make_pick()
+    session.add(pick)
+    session.flush()
+
+    decision = ScannerDecision(
+        kind=DecisionKind.PICKED,
+        decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ticker="ABCD",
+        pick_id=pick.id,
+    )
+    session.add(decision)
+    session.commit()
+
+    fetched = session.get(ScannerDecision, decision.id)
+    assert fetched is not None
+    assert fetched.kind == DecisionKind.PICKED
+    assert fetched.ticker == "ABCD"
+    assert fetched.pick_id == pick.id
+    assert fetched.pick is not None
+    assert fetched.pick.ticker == "ABCD"
+    assert fetched.reason is None
+    assert fetched.gap_start is None
+    assert fetched.gap_end is None
+    assert fetched.rejection_reason is None
+
+
+def test_decision_stale_feed_round_trip(session: Session) -> None:
+    decision = ScannerDecision(
+        kind=DecisionKind.STALE_FEED,
+        decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ticker=None,
+        reason="quote feed stale (5.2s since last tick)",
+    )
+    session.add(decision)
+    session.commit()
+
+    fetched = session.get(ScannerDecision, decision.id)
+    assert fetched is not None
+    assert fetched.kind == DecisionKind.STALE_FEED
+    assert fetched.ticker is None
+    assert fetched.pick_id is None
+    assert fetched.reason == "quote feed stale (5.2s since last tick)"
+
+
+def test_decision_feed_gap_round_trip(session: Session) -> None:
+    decision = ScannerDecision(
+        kind=DecisionKind.FEED_GAP,
+        decision_ts=datetime(2026, 5, 2, 14, 35, tzinfo=UTC),
+        gap_start=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        gap_end=datetime(2026, 5, 2, 14, 33, tzinfo=UTC),
+    )
+    session.add(decision)
+    session.commit()
+
+    fetched = session.get(ScannerDecision, decision.id)
+    assert fetched is not None
+    assert fetched.kind == DecisionKind.FEED_GAP
+    assert fetched.gap_start == datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    assert fetched.gap_end == datetime(2026, 5, 2, 14, 33, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    list(RejectionReason),
+)
+def test_decision_rejected_round_trip(
+    session: Session,
+    reason: RejectionReason,
+) -> None:
+    decision = ScannerDecision(
+        kind=DecisionKind.REJECTED,
+        decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ticker="WXYZ",
+        rejection_reason=reason,
+    )
+    session.add(decision)
+    session.commit()
+
+    fetched = session.get(ScannerDecision, decision.id)
+    assert fetched is not None
+    assert fetched.kind == DecisionKind.REJECTED
+    assert fetched.rejection_reason == reason
+    assert fetched.pick_id is None
+
+
+def test_rejection_reason_order_matches_filter_chain() -> None:
+    """The enum order encodes 'first failing filter' priority -- A4 contract.
+
+    A rename or reorder is a contract break; lock it down here so #51's
+    wiring lands without surprises.
+    """
+    assert [r.value for r in RejectionReason] == [
+        "no_snapshot",
+        "missing_baseline",
+        "missing_float",
+        "rel_volume",
+        "pct_change",
+        "price_band",
+        "float_size",
+    ]
+
+
+def test_decision_kind_includes_reserved_rejected() -> None:
+    assert {k.value for k in DecisionKind} == {
+        "picked",
+        "stale_feed",
+        "feed_gap",
+        "rejected",
+    }


### PR DESCRIPTION
## Summary

Phase 2 — Atom A4 (#43). Lands the durable storage layer the scanner journal sits on. A5 (#44) will write through `DecisionSink` directly into these tables; A6 (#45) and A7 (#46) read from the same model surface. Decision **D2** (#36) is the choice this PR materializes: SQLite via SQLAlchemy 2 + Alembic.

## What's in here

**Models** (`src/ross_trading/journal/models.py`)
- `Pick` — mirrors `ScannerPick`. `headline_count` is an explicit `Integer` column (first-class, not derived) so Phase 3 retrospectives can correlate outcome quality with headline volume.
- `WatchlistEntry` — open-ended membership (`added_at`, `removed_at`) with a partial index on `(ticker)` filtered by `removed_at IS NULL`, so A7's "currently on watchlist" lookups stay cheap.
- `ScannerDecision` — mirrors the four-kind shape; `pick_id` is FK-nullable (set only when `kind=picked`), `rejection_reason` is enum-nullable (set only when `kind=rejected`).
- `DecisionKind` (4 values) — `rejected` is reserved for #51 so that issue lands as wiring only.
- `RejectionReason` (7 values) — `no_snapshot, missing_baseline, missing_float, rel_volume, pct_change, price_band, float_size`. Order matches the AND-chain in `Scanner.scan` so the enum itself encodes "first failing filter" priority. The literal values are the contract referenced by #51 and locked down by `test_rejection_reason_order_matches_filter_chain`.

**Type decorators** (`src/ross_trading/journal/types.py`)
- `TzAwareUTC` — rejects naive datetimes on bind (matches `ScannerDecision`'s tz-awareness invariant), persists ISO-8601 UTC TEXT, re-attaches UTC on load. SQLite has no native tz type and SA's `DateTime(timezone=True)` is a no-op there.
- `DecimalText` — persists `Decimal` as TEXT. SA's `Numeric` degrades to FLOAT on SQLite and would silently lose precision on `rel_volume` / `pct_change` / `price`. Mirrors the rigor in `data/cache.py`.

**Engine** (`src/ross_trading/journal/engine.py`)
- `connect_args={"isolation_level": "IMMEDIATE"}` per the issue body, plus a `begin` event listener that issues `BEGIN IMMEDIATE`. Both are needed because SA 2.x overrides the pysqlite driver's `isolation_level` at runtime — the listener does the substantive work.
- WAL pragma installed via `connect` event listener.
- In-memory URLs auto-switch to `StaticPool` so tests share one connection across the engine.

**Alembic** (`alembic.ini`, `src/ross_trading/journal/migrations/`)
- `render_as_batch=True` for SQLite ALTER limitations (no-op on Postgres, keeps every revision portable).
- `env.py` honors a connection injected via `Config.attributes['connection']`, so the session-scoped test fixture upgrades head against the same in-memory engine the tests use.
- Initial migration creates all three tables with the full four-value `decision_kind` enum and seven-value `rejection_reason` enum populated from day one.

## Why SQLAlchemy here when `data/cache.py` uses raw `sqlite3`?

The split is deliberate and now documented at both sites (`journal/__init__.py` references `data/cache.py`):

- `data/cache.py` is a hot-path, append-only analytic cache (daily volumes, EMAs). Schema is small and stable; raw `sqlite3` keeps it dependency-light and sub-millisecond.
- The journal is the durable record of agent decisions across versions. Schema *will* evolve as scanner outputs evolve. SA 2.x typed ORM + Alembic gives us migration ergonomics today and the Postgres-swap option later.

## Acceptance criteria

| Criterion | Where |
|---|---|
| `mypy --strict` passes with SA 2 typed models | full repo: 71 source files, 0 issues |
| Migrations apply forward and reverse cleanly from empty | `tests/integration/test_journal_migrations.py::test_upgrade_head_then_downgrade_base` |
| Schema captures every `ScannerPick` field + rejection-reason enum | `Pick` model + `ScannerDecision.rejection_reason`; round-tripped per-reason via parametrized test |
| `headline_count` is an explicit `Integer` column on `Pick` | `models.py` `Pick.headline_count` |
| `journal_mode=WAL` and `isolation_level=IMMEDIATE` verified on engine create | `tests/unit/test_journal_engine.py` (3 tests) |

## Tests

24 new tests, all green; 202/202 in the full suite.

- `tests/unit/test_journal_models.py` (19) — round-trip every model, decimal precision preservation, non-UTC tz normalization, naive datetime rejection, watchlist open/closed/active-query, every decision kind including parametrized rejection-reason coverage, enum-order contract.
- `tests/unit/test_journal_engine.py` (3) — `JOURNAL_CONNECT_ARGS` pin, WAL on file-based engine, `BEGIN IMMEDIATE` captured via `before_cursor_execute`.
- `tests/integration/test_journal_migrations.py` (2) — session-scoped `migrated_engine` fixture, full upgrade/downgrade round trip.

## Out of scope

- Writer logic — A5 (#44).
- Async I/O — `aiosqlite` deferred until A5 actually needs it.
- Postgres swap — the WHY-comment in `journal/__init__.py` is the only acknowledgement.
- Wiring `RejectionReason` to actual scanner output — A4 just lands the schema and enum surface; #51 does the wiring.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)