### PR TITLE
feat(journal): JournalWriter sink + scanner_decisions CHECK constraints (#44)

### DIFF
--- a/src/ross_trading/journal/migrations/versions/0002_scanner_decisions_check_constraints.py
+++ b/src/ross_trading/journal/migrations/versions/0002_scanner_decisions_check_constraints.py
@@ -1,0 +1,65 @@
+"""scanner_decisions: kind -> field-population CHECK constraints.
+
+Revision ID: 0002_check_constraints
+Revises: 0001_initial
+Create Date: 2026-05-02 00:00:01
+
+Carries the deferred P2 review item from #43 / PR #54: enforce the
+``kind`` -> field-population invariants at the schema level so a buggy
+writer cannot silently insert a malformed row.
+
+Five CHECKs on ``scanner_decisions`` (names + conditions live in
+``_CONSTRAINTS`` below; documented inline rather than in this docstring
+to keep lines under the project's line-length cap).
+
+SQLite cannot ``ALTER TABLE ... ADD CHECK`` directly, so this revision
+uses Alembic batch mode (``with op.batch_alter_table``) which rewrites
+as ``CREATE TABLE new + COPY + DROP old + RENAME``. Round-trip (upgrade
++ downgrade) on a populated DB is verified by
+``tests/integration/test_journal_check_constraints.py::test_upgrade_then_downgrade_with_seeded_rows``.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0002_check_constraints"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+_CONSTRAINTS = (
+    (
+        "ck_scanner_decisions_picked_pick_id",
+        "(kind = 'picked') = (pick_id IS NOT NULL)",
+    ),
+    (
+        "ck_scanner_decisions_rejected_reason",
+        "(kind = 'rejected') = (rejection_reason IS NOT NULL)",
+    ),
+    (
+        "ck_scanner_decisions_feed_gap_start",
+        "(kind = 'feed_gap') = (gap_start IS NOT NULL)",
+    ),
+    (
+        "ck_scanner_decisions_feed_gap_end",
+        "(kind = 'feed_gap') = (gap_end IS NOT NULL)",
+    ),
+    (
+        "ck_scanner_decisions_ticker_required",
+        "kind IN ('stale_feed', 'feed_gap') OR ticker IS NOT NULL",
+    ),
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("scanner_decisions") as batch_op:
+        for name, condition in _CONSTRAINTS:
+            batch_op.create_check_constraint(name, condition)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("scanner_decisions") as batch_op:
+        for name, _ in _CONSTRAINTS:
+            batch_op.drop_constraint(name, type_="check")

--- a/src/ross_trading/journal/models.py
+++ b/src/ross_trading/journal/models.py
@@ -27,6 +27,7 @@ from decimal import Decimal  # noqa: TC003 -- SA 2.x evals Mapped[Decimal] at ru
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     Enum,
     ForeignKey,
     Index,
@@ -171,4 +172,28 @@ class ScannerDecision(Base):
     __table_args__ = (
         Index("ix_scanner_decisions_decision_ts", "decision_ts"),
         Index("ix_scanner_decisions_kind_ts", "kind", "decision_ts"),
+        # Kind -> field-population invariants. Mirrors migration 0002
+        # (P2 review item from #43 / PR #54). Declared here so
+        # ``Base.metadata.create_all`` -- used by unit tests -- produces
+        # the same schema as ``alembic upgrade head``.
+        CheckConstraint(
+            "(kind = 'picked') = (pick_id IS NOT NULL)",
+            name="ck_scanner_decisions_picked_pick_id",
+        ),
+        CheckConstraint(
+            "(kind = 'rejected') = (rejection_reason IS NOT NULL)",
+            name="ck_scanner_decisions_rejected_reason",
+        ),
+        CheckConstraint(
+            "(kind = 'feed_gap') = (gap_start IS NOT NULL)",
+            name="ck_scanner_decisions_feed_gap_start",
+        ),
+        CheckConstraint(
+            "(kind = 'feed_gap') = (gap_end IS NOT NULL)",
+            name="ck_scanner_decisions_feed_gap_end",
+        ),
+        CheckConstraint(
+            "kind IN ('stale_feed', 'feed_gap') OR ticker IS NOT NULL",
+            name="ck_scanner_decisions_ticker_required",
+        ),
     )

--- a/src/ross_trading/journal/writer.py
+++ b/src/ross_trading/journal/writer.py
@@ -1,0 +1,190 @@
+"""Concrete :class:`DecisionSink` backed by the SQLAlchemy session factory.
+
+Phase 2 -- Atom A5 (#44). Implements the
+:class:`ross_trading.scanner.decisions.DecisionSink` Protocol against the
+journal models defined in :mod:`ross_trading.journal.models`. Two surfaces:
+
+* :meth:`JournalWriter.emit` -- the A3 hot path. Each call opens a session,
+  writes one decision row (plus a linked :class:`Pick` row for ``picked``),
+  and commits. Each call is its own atomic 1-row transaction.
+* :meth:`JournalWriter.record_scan` -- the batch API. Picks and rejections
+  for a single tick land in one session and are committed together. This
+  is the "one tick = one transaction" surface tested for atomic partial-
+  failure rollback.
+
+**Atomicity scope today.** A3's loop calls :meth:`emit` N times per tick
+(one per pick, plus stale_feed / feed_gap as they occur), so a crash mid-
+tick can leave a partial picked-set on disk -- under-recording, not
+inconsistency. The current three kinds are structurally near-atomic
+(stale_feed and feed_gap fire alone; only "pick #2 vs pick #3 of the same
+tick" can split). A3 is stateless across ticks, so the next tick runs
+fresh and downstream invariants hold. When #51 lands the fourth ``rejected``
+kind, picks + rejections need true tick-atomicity -- splitting them would
+systematically overstate scanner precision -- and #51 will migrate A3's
+loop from N x :meth:`emit` to a single :meth:`record_scan` per tick.
+
+**Transactional configuration.** This module intentionally does not issue
+``BEGIN IMMEDIATE`` per call. The journal :class:`Engine` installs a
+``begin``-event listener that emits ``BEGIN IMMEDIATE`` on every transaction
+start; see :mod:`ross_trading.journal.engine` for the rationale (SQLAlchemy
+2.x overrides the pysqlite ``isolation_level`` connect-arg at runtime, so
+the engine-level listener is the substantive guarantee).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ross_trading.journal.models import (
+    DecisionKind,
+    Pick,
+    RejectionReason,
+)
+from ross_trading.journal.models import (
+    ScannerDecision as ScannerDecisionRow,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from datetime import datetime
+
+    from sqlalchemy.orm import Session, sessionmaker
+
+    from ross_trading.scanner.decisions import ScannerDecision
+    from ross_trading.scanner.types import ScannerPick
+
+
+class JournalWriter:
+    """Concrete :class:`DecisionSink` backed by a SQLAlchemy session factory."""
+
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    def emit(self, decision: ScannerDecision) -> None:
+        """Write one decision row in its own transaction.
+
+        See module docstring for the atomicity scope today vs. after #51.
+        """
+        with self._session_factory() as session:
+            self._add(session, decision)
+            session.commit()
+
+    def record_scan(
+        self,
+        decision_ts: datetime,
+        picks: Sequence[ScannerPick],
+        rejected: Mapping[str, RejectionReason],
+    ) -> None:
+        """Persist all picks and rejections for one scan tick atomically.
+
+        The whole call is one transaction: a constraint violation on any
+        row rolls back every row written in this call. ``session.begin()``
+        ensures BEGIN/COMMIT pair fires even when both inputs are empty,
+        keeping the "one tick = one transaction" property unconditional.
+        """
+        with self._session_factory() as session, session.begin():
+            for pick in picks:
+                self._add_picked(session, decision_ts=decision_ts, pick=pick)
+            for ticker, reason in rejected.items():
+                self._add_rejected(
+                    session,
+                    decision_ts=decision_ts,
+                    ticker=ticker,
+                    reason=reason,
+                )
+
+    # ----------------------------------------------------------- internals
+
+    def _add(self, session: Session, decision: ScannerDecision) -> None:
+        if decision.kind == "picked":
+            assert decision.pick is not None  # noqa: S101 -- ScannerDecision invariant
+            self._add_picked(
+                session,
+                decision_ts=decision.decision_ts,
+                pick=decision.pick,
+            )
+            return
+        if decision.kind == "stale_feed":
+            session.add(
+                ScannerDecisionRow(
+                    kind=DecisionKind.STALE_FEED,
+                    decision_ts=decision.decision_ts,
+                    ticker=decision.ticker,
+                    pick_id=None,
+                    reason=decision.reason,
+                    gap_start=None,
+                    gap_end=None,
+                    rejection_reason=None,
+                )
+            )
+            return
+        if decision.kind == "feed_gap":
+            session.add(
+                ScannerDecisionRow(
+                    kind=DecisionKind.FEED_GAP,
+                    decision_ts=decision.decision_ts,
+                    ticker=decision.ticker,
+                    pick_id=None,
+                    reason=decision.reason,
+                    gap_start=decision.gap_start,
+                    gap_end=decision.gap_end,
+                    rejection_reason=None,
+                )
+            )
+            return
+        msg = f"unknown ScannerDecision.kind: {decision.kind!r}"
+        raise ValueError(msg)
+
+    def _add_picked(
+        self,
+        session: Session,
+        *,
+        decision_ts: datetime,
+        pick: ScannerPick,
+    ) -> None:
+        pick_row = Pick(
+            ticker=pick.ticker,
+            ts=pick.ts,
+            rel_volume=pick.rel_volume,
+            pct_change=pick.pct_change,
+            price=pick.price,
+            float_shares=pick.float_shares,
+            news_present=pick.news_present,
+            headline_count=pick.headline_count,
+            rank=pick.rank,
+        )
+        session.add(pick_row)
+        session.flush()  # populate pick_row.id for the FK below
+        session.add(
+            ScannerDecisionRow(
+                kind=DecisionKind.PICKED,
+                decision_ts=decision_ts,
+                ticker=pick.ticker,
+                pick_id=pick_row.id,
+                reason=None,
+                gap_start=None,
+                gap_end=None,
+                rejection_reason=None,
+            )
+        )
+
+    def _add_rejected(
+        self,
+        session: Session,
+        *,
+        decision_ts: datetime,
+        ticker: str,
+        reason: RejectionReason,
+    ) -> None:
+        session.add(
+            ScannerDecisionRow(
+                kind=DecisionKind.REJECTED,
+                decision_ts=decision_ts,
+                ticker=ticker,
+                pick_id=None,
+                reason=None,
+                gap_start=None,
+                gap_end=None,
+                rejection_reason=reason,
+            )
+        )

--- a/tests/integration/test_journal_check_constraints.py
+++ b/tests/integration/test_journal_check_constraints.py
@@ -1,0 +1,342 @@
+"""Atom A5 (#44) -- CHECK-constraint enforcement on ``scanner_decisions``.
+
+Carries the deferred P2 review item from #43 / PR #54: the kind ->
+field-population invariants now live at the schema level, so a buggy
+writer cannot silently insert a malformed row.
+
+The five CHECKs (introduced by migration ``0002_*``):
+
+* ``(kind = 'picked')   = (pick_id IS NOT NULL)``
+* ``(kind = 'rejected') = (rejection_reason IS NOT NULL)``
+* ``(kind = 'feed_gap') = (gap_start IS NOT NULL)``
+* ``(kind = 'feed_gap') = (gap_end IS NOT NULL)``
+* ``kind IN ('stale_feed', 'feed_gap') OR ticker IS NOT NULL``
+
+Each test inserts a violating row via ``exec_driver_sql`` so the assertion
+is "the database rejects this," not "the ORM/writer happens to refuse."
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ross_trading.journal.engine import create_journal_engine
+from ross_trading.journal.models import (
+    DecisionKind,
+    Pick,
+    RejectionReason,
+)
+from ross_trading.journal.models import (
+    ScannerDecision as ScannerDecisionRow,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy.engine import Connection, Engine
+
+pytestmark = pytest.mark.integration
+
+_MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "ross_trading"
+    / "journal"
+    / "migrations"
+)
+
+
+def _alembic_config(connection: Connection) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    cfg.attributes["connection"] = connection
+    return cfg
+
+
+@pytest.fixture
+def migrated_engine() -> Iterator[Engine]:
+    """Fresh engine migrated to head (function-scoped: each test isolated)."""
+    engine = create_journal_engine("sqlite://")
+    with engine.begin() as conn:
+        command.upgrade(_alembic_config(conn), "head")
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+# ---------------------------------------------------- per-CHECK violations
+
+
+def test_picked_without_pick_id_rejected(migrated_engine: Engine) -> None:
+    """``kind='picked'`` requires ``pick_id IS NOT NULL``."""
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('picked', '2026-05-02T14:30:00+00:00', 'ABCD', NULL, NULL, NULL, NULL, NULL)",
+        )
+
+
+def test_non_picked_with_pick_id_rejected(migrated_engine: Engine) -> None:
+    """The biconditional cuts both ways: non-picked rows must NOT carry a pick_id."""
+    # First seed a real Pick row to satisfy the FK (otherwise we'd hit the
+    # foreign-key check before the CHECK).
+    with migrated_engine.begin() as conn:
+        conn.exec_driver_sql(
+            "INSERT INTO picks "
+            "(ticker, ts, rel_volume, pct_change, price, "
+            "float_shares, news_present, headline_count, rank) "
+            "VALUES ('ABCD', '2026-05-02T14:30:00+00:00', '12.5', '18.75', '3.42', "
+            "8500000, 1, 4, 1)",
+        )
+        pick_id = conn.exec_driver_sql("SELECT id FROM picks").scalar_one()
+
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('stale_feed', '2026-05-02T14:30:00+00:00', NULL, :pick_id, "
+            "'stale', NULL, NULL, NULL)",
+            {"pick_id": pick_id},
+        )
+
+
+def test_rejected_without_rejection_reason_rejected(migrated_engine: Engine) -> None:
+    """``kind='rejected'`` requires ``rejection_reason IS NOT NULL``."""
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, "
+            "gap_start, gap_end, rejection_reason) "
+            "VALUES ('rejected', '2026-05-02T14:30:00+00:00', 'ABCD', "
+            "NULL, NULL, NULL, NULL, NULL)",
+        )
+
+
+def test_non_rejected_with_rejection_reason_rejected(migrated_engine: Engine) -> None:
+    """Biconditional: only ``rejected`` rows may carry a rejection_reason."""
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('stale_feed', '2026-05-02T14:30:00+00:00', NULL, NULL, "
+            "'stale', NULL, NULL, 'rel_volume')",
+        )
+
+
+def test_feed_gap_without_gap_start_rejected(migrated_engine: Engine) -> None:
+    """``kind='feed_gap'`` requires ``gap_start IS NOT NULL``."""
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('feed_gap', '2026-05-02T14:30:00+00:00', NULL, NULL, NULL, "
+            "NULL, '2026-05-02T14:30:00+00:00', NULL)",
+        )
+
+
+def test_feed_gap_without_gap_end_rejected(migrated_engine: Engine) -> None:
+    """``kind='feed_gap'`` requires ``gap_end IS NOT NULL``."""
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('feed_gap', '2026-05-02T14:30:00+00:00', NULL, NULL, NULL, "
+            "'2026-05-02T14:29:00+00:00', NULL, NULL)",
+        )
+
+
+def test_non_feed_gap_with_gap_start_rejected(migrated_engine: Engine) -> None:
+    """Biconditional: gap_start belongs only on ``feed_gap`` rows."""
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('stale_feed', '2026-05-02T14:30:00+00:00', NULL, NULL, NULL, "
+            "'2026-05-02T14:29:00+00:00', NULL, NULL)",
+        )
+
+
+def test_picked_without_ticker_rejected(migrated_engine: Engine) -> None:
+    """``kind='picked'`` requires ``ticker IS NOT NULL`` (CHECK 5).
+
+    First seed a real Pick row to satisfy the FK so this test isolates the
+    ticker CHECK rather than tripping the FK first.
+    """
+    with migrated_engine.begin() as conn:
+        conn.exec_driver_sql(
+            "INSERT INTO picks "
+            "(ticker, ts, rel_volume, pct_change, price, "
+            "float_shares, news_present, headline_count, rank) "
+            "VALUES ('ABCD', '2026-05-02T14:30:00+00:00', '12.5', '18.75', '3.42', "
+            "8500000, 1, 4, 1)",
+        )
+        pick_id = conn.exec_driver_sql("SELECT id FROM picks").scalar_one()
+
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('picked', '2026-05-02T14:30:00+00:00', NULL, :pick_id, "
+            "NULL, NULL, NULL, NULL)",
+            {"pick_id": pick_id},
+        )
+
+
+def test_rejected_without_ticker_rejected(migrated_engine: Engine) -> None:
+    """``kind='rejected'`` requires ``ticker IS NOT NULL`` (CHECK 5)."""
+    with migrated_engine.begin() as conn, pytest.raises(IntegrityError):
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('rejected', '2026-05-02T14:30:00+00:00', NULL, NULL, NULL, "
+            "NULL, NULL, 'rel_volume')",
+        )
+
+
+# ----------------------- happy-path inserts must continue to succeed
+
+
+def test_valid_picked_insert_accepted(migrated_engine: Engine) -> None:
+    """Sanity: a correctly-shaped ``picked`` row passes every CHECK."""
+    with migrated_engine.begin() as conn:
+        conn.exec_driver_sql(
+            "INSERT INTO picks "
+            "(ticker, ts, rel_volume, pct_change, price, "
+            "float_shares, news_present, headline_count, rank) "
+            "VALUES ('ABCD', '2026-05-02T14:30:00+00:00', '12.5', '18.75', '3.42', "
+            "8500000, 1, 4, 1)",
+        )
+        pick_id = conn.exec_driver_sql("SELECT id FROM picks").scalar_one()
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('picked', '2026-05-02T14:30:00+00:00', 'ABCD', :pick_id, "
+            "NULL, NULL, NULL, NULL)",
+            {"pick_id": pick_id},
+        )
+
+
+def test_valid_stale_feed_insert_accepted(migrated_engine: Engine) -> None:
+    with migrated_engine.begin() as conn:
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('stale_feed', '2026-05-02T14:30:00+00:00', NULL, NULL, "
+            "'feed stale by 7.0s', NULL, NULL, NULL)",
+        )
+
+
+def test_valid_feed_gap_insert_accepted(migrated_engine: Engine) -> None:
+    with migrated_engine.begin() as conn:
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('feed_gap', '2026-05-02T14:30:00+00:00', NULL, NULL, "
+            "'reset', '2026-05-02T14:29:00+00:00', '2026-05-02T14:30:00+00:00', NULL)",
+        )
+
+
+def test_valid_rejected_insert_accepted(migrated_engine: Engine) -> None:
+    with migrated_engine.begin() as conn:
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, gap_start, gap_end, rejection_reason) "
+            "VALUES ('rejected', '2026-05-02T14:30:00+00:00', 'ABCD', NULL, "
+            "NULL, NULL, NULL, 'rel_volume')",
+        )
+
+
+# ---------------------------- migration round-trip with seeded rows
+
+
+def test_upgrade_then_downgrade_with_seeded_rows() -> None:
+    """0001 -> seed one row of each kind -> upgrade head -> downgrade base.
+
+    Ensures the 0002 CHECK migration applies forward AND reverse cleanly
+    against a populated database. SQLite cannot ``ALTER TABLE ADD CHECK``
+    directly, so the migration must use Alembic batch-mode (which rewrites
+    as CREATE NEW + COPY + DROP OLD + RENAME). Round-trip with seeded data
+    proves no rows orphaned in either direction.
+    """
+    engine = create_journal_engine("sqlite://")
+    try:
+        # Stage 1: upgrade to 0001 (pre-CHECK) and seed one row of each kind.
+        with engine.begin() as conn:
+            command.upgrade(_alembic_config(conn), "0001_initial")
+
+        with Session(engine) as session:
+            pick = Pick(
+                ticker="ABCD",
+                ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+                rel_volume=Decimal("12.5"),
+                pct_change=Decimal("18.75"),
+                price=Decimal("3.42"),
+                float_shares=8_500_000,
+                news_present=True,
+                headline_count=4,
+                rank=1,
+            )
+            session.add(pick)
+            session.flush()
+            session.add_all([
+                ScannerDecisionRow(
+                    kind=DecisionKind.PICKED,
+                    decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+                    ticker="ABCD",
+                    pick_id=pick.id,
+                ),
+                ScannerDecisionRow(
+                    kind=DecisionKind.STALE_FEED,
+                    decision_ts=datetime(2026, 5, 2, 14, 31, tzinfo=UTC),
+                    reason="feed stale by 7.0s",
+                ),
+                ScannerDecisionRow(
+                    kind=DecisionKind.FEED_GAP,
+                    decision_ts=datetime(2026, 5, 2, 14, 32, tzinfo=UTC),
+                    reason="reset",
+                    gap_start=datetime(2026, 5, 2, 14, 31, tzinfo=UTC),
+                    gap_end=datetime(2026, 5, 2, 14, 32, tzinfo=UTC),
+                ),
+                ScannerDecisionRow(
+                    kind=DecisionKind.REJECTED,
+                    decision_ts=datetime(2026, 5, 2, 14, 33, tzinfo=UTC),
+                    ticker="WXYZ",
+                    rejection_reason=RejectionReason.REL_VOLUME,
+                ),
+            ])
+            session.commit()
+
+        # Stage 2: upgrade head (applies 0002 CHECK migration) on populated DB.
+        with engine.begin() as conn:
+            command.upgrade(_alembic_config(conn), "head")
+
+        # All four seeded rows survived.
+        with Session(engine) as session:
+            count = session.query(ScannerDecisionRow).count()
+            pick_count = session.query(Pick).count()
+        assert count == 4
+        assert pick_count == 1
+
+        # Stage 3: downgrade back to 0001 with the rows still present.
+        with engine.begin() as conn:
+            command.downgrade(_alembic_config(conn), "0001_initial")
+
+        with Session(engine) as session:
+            count = session.query(ScannerDecisionRow).count()
+            pick_count = session.query(Pick).count()
+        assert count == 4, "downgrade lost decision rows"
+        assert pick_count == 1, "downgrade lost pick rows"
+
+    finally:
+        engine.dispose()

--- a/tests/integration/test_journal_migrations.py
+++ b/tests/integration/test_journal_migrations.py
@@ -8,6 +8,7 @@ session-scoped fixture matches the ``HistoricalCache`` testing pattern.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,7 @@ from sqlalchemy.orm import Session
 from ross_trading.journal.engine import create_journal_engine
 from ross_trading.journal.models import (
     DecisionKind,
+    Pick,
     RejectionReason,
     ScannerDecision,
 )
@@ -115,10 +117,26 @@ def test_orm_inserts_persist_lowercase_enum_values_against_migration(
         Session(bind=outer_conn) as session,
         session.begin_nested() as nested,
     ):
+        # Seed a real Pick so the picked decision satisfies the
+        # ``ck_scanner_decisions_picked_pick_id`` CHECK from migration 0002.
+        pick = Pick(
+            ticker="ABCD",
+            ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+            rel_volume=Decimal("12.5"),
+            pct_change=Decimal("18.75"),
+            price=Decimal("3.42"),
+            float_shares=8_500_000,
+            news_present=True,
+            headline_count=4,
+            rank=1,
+        )
+        session.add(pick)
+        session.flush()
         picked = ScannerDecision(
             kind=DecisionKind.PICKED,
             decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
             ticker="ABCD",
+            pick_id=pick.id,
         )
         rejected = ScannerDecision(
             kind=DecisionKind.REJECTED,

--- a/tests/integration/test_scanner_loop_journal.py
+++ b/tests/integration/test_scanner_loop_journal.py
@@ -1,0 +1,173 @@
+"""Atom A5 (#44) -- end-to-end smoke test: ScannerLoop + real JournalWriter.
+
+Drives the loop for a few ticks against an in-memory engine with a real
+:class:`JournalWriter` as the :class:`DecisionSink`, then asserts rows
+landed. The Protocol seam is the test boundary, so existing A3 tests stay
+on :class:`FakeDecisionSink`; this test specifically covers the wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import select
+
+from ross_trading.core.clock import VirtualClock
+from ross_trading.data.types import Bar, FloatRecord
+from ross_trading.data.universe import CachedUniverseProvider
+from ross_trading.journal.engine import (
+    create_journal_engine,
+    create_session_factory,
+)
+from ross_trading.journal.models import (
+    Base,
+    DecisionKind,
+    Pick,
+)
+from ross_trading.journal.models import (
+    ScannerDecision as ScannerDecisionRow,
+)
+from ross_trading.journal.writer import JournalWriter
+from ross_trading.scanner.loop import ScannerLoop
+from ross_trading.scanner.scanner import Scanner
+from ross_trading.scanner.types import ScannerSnapshot
+from tests.fakes.snapshot_assembler import FakeSnapshotAssembler
+from tests.fakes.universe import FakeUniverseProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy.engine import Engine
+
+pytestmark = pytest.mark.integration
+
+DAY = date(2025, 1, 2)
+WINDOW_OPEN = datetime(2025, 1, 2, 12, 0, tzinfo=UTC)
+
+
+def _bar(symbol: str, ts: datetime) -> Bar:
+    return Bar(
+        symbol=symbol, ts=ts, timeframe="M1",
+        open=Decimal("5.00"), high=Decimal("5.50"),
+        low=Decimal("4.95"), close=Decimal("5.50"), volume=5_000_000,
+    )
+
+
+def _snap(symbol: str, ts: datetime) -> ScannerSnapshot:
+    return ScannerSnapshot(
+        bar=_bar(symbol, ts),
+        last=Decimal("5.50"),
+        prev_close=Decimal("5.00"),
+        baseline_30d=Decimal("1000000"),
+        float_record=FloatRecord(
+            ticker=symbol, as_of=DAY, float_shares=8_500_000,
+            shares_outstanding=12_000_000, source="test",
+        ),
+        headlines=(),
+    )
+
+
+@pytest.fixture
+def engine() -> Iterator[Engine]:
+    eng = create_journal_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    try:
+        yield eng
+    finally:
+        eng.dispose()
+
+
+async def test_scanner_loop_with_real_journal_writer_persists_picks(
+    engine: Engine,
+) -> None:
+    """Three qualifying ticks => three Pick + three ScannerDecision rows on disk."""
+    session_factory = create_session_factory(engine)
+    writer = JournalWriter(session_factory)
+
+    snap = _snap("AVTX", WINDOW_OPEN)
+    script = {
+        WINDOW_OPEN: ({"AVTX": snap}, WINDOW_OPEN),
+        WINDOW_OPEN + timedelta(seconds=2): (
+            {"AVTX": snap}, WINDOW_OPEN + timedelta(seconds=2),
+        ),
+        WINDOW_OPEN + timedelta(seconds=4): (
+            {"AVTX": snap}, WINDOW_OPEN + timedelta(seconds=4),
+        ),
+    }
+    clock = VirtualClock(WINDOW_OPEN)
+    upstream = FakeUniverseProvider({DAY: frozenset(["AVTX"])})
+    loop = ScannerLoop(
+        scanner=Scanner(),
+        universe_provider=CachedUniverseProvider(upstream, clock=clock),
+        snapshot_assembler=FakeSnapshotAssembler(script),
+        decision_sink=writer,
+        clock=clock,
+        tick_interval_s=2.0,
+        staleness_threshold_s=5.0,
+    )
+
+    task = asyncio.create_task(loop.run())
+    while clock.now() < WINDOW_OPEN + timedelta(seconds=6):
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    with session_factory() as session:
+        decisions = session.execute(
+            select(ScannerDecisionRow).order_by(ScannerDecisionRow.id)
+        ).scalars().all()
+        picks = session.execute(select(Pick)).scalars().all()
+
+    assert len(decisions) == 3, "expected one decision per tick"
+    assert all(d.kind is DecisionKind.PICKED for d in decisions)
+    assert {d.ticker for d in decisions} == {"AVTX"}
+    assert len(picks) == 3, "each emit('picked') writes a fresh Pick row"
+    assert {p.ticker for p in picks} == {"AVTX"}
+    # Decision rows reference the Pick rows they were emitted with.
+    assert {d.pick_id for d in decisions} == {p.id for p in picks}
+
+
+async def test_scanner_loop_with_real_journal_writer_persists_stale_feed(
+    engine: Engine,
+) -> None:
+    """A stale tick lands as a stale_feed row through the real writer."""
+    session_factory = create_session_factory(engine)
+    writer = JournalWriter(session_factory)
+
+    # Quote ts is 10s before the anchor -> staleness 10s > threshold 5s.
+    stale_quote_ts = WINDOW_OPEN - timedelta(seconds=10)
+    script = {WINDOW_OPEN: ({"AVTX": _snap("AVTX", WINDOW_OPEN)}, stale_quote_ts)}
+
+    clock = VirtualClock(WINDOW_OPEN)
+    upstream = FakeUniverseProvider({DAY: frozenset(["AVTX"])})
+    loop = ScannerLoop(
+        scanner=Scanner(),
+        universe_provider=CachedUniverseProvider(upstream, clock=clock),
+        snapshot_assembler=FakeSnapshotAssembler(script),
+        decision_sink=writer,
+        clock=clock,
+        tick_interval_s=2.0,
+        staleness_threshold_s=5.0,
+    )
+
+    task = asyncio.create_task(loop.run())
+    while clock.now() < WINDOW_OPEN + timedelta(seconds=2):
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    with session_factory() as session:
+        decisions = session.execute(select(ScannerDecisionRow)).scalars().all()
+    assert len(decisions) == 1
+    row = decisions[0]
+    assert row.kind is DecisionKind.STALE_FEED
+    assert row.ticker is None
+    assert row.pick_id is None
+    assert row.reason is not None
+    assert "stale" in row.reason

--- a/tests/unit/test_journal_writer.py
+++ b/tests/unit/test_journal_writer.py
@@ -1,0 +1,393 @@
+"""Atom A5 (#44) -- JournalWriter unit tests.
+
+Round-trips every ``ScannerDecision`` kind through ``emit()``, asserts
+``record_scan`` commits exactly once per call (SA event listener),
+verifies partial-failure rollback, and pins the ``RejectionReason``
+enum's seven values as the #51 contract.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import event, select
+from sqlalchemy.exc import IntegrityError
+
+from ross_trading.journal.engine import (
+    create_journal_engine,
+    create_session_factory,
+)
+from ross_trading.journal.models import (
+    Base,
+    DecisionKind,
+    Pick,
+    RejectionReason,
+)
+from ross_trading.journal.models import (
+    ScannerDecision as ScannerDecisionRow,
+)
+from ross_trading.journal.writer import JournalWriter
+from ross_trading.scanner.decisions import ScannerDecision
+from ross_trading.scanner.types import ScannerPick
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.orm import Session, sessionmaker
+
+# --------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def engine() -> Iterator[Engine]:
+    eng = create_journal_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    try:
+        yield eng
+    finally:
+        eng.dispose()
+
+
+@pytest.fixture
+def session_factory(engine: Engine) -> sessionmaker[Session]:
+    return create_session_factory(engine)
+
+
+@pytest.fixture
+def writer(session_factory: sessionmaker[Session]) -> JournalWriter:
+    return JournalWriter(session_factory)
+
+
+# ------------------------------------------------------------------- helpers
+
+
+def _pick(
+    *,
+    ticker: str = "ABCD",
+    ts: datetime | None = None,
+    rank: int = 1,
+) -> ScannerPick:
+    return ScannerPick(
+        ticker=ticker,
+        ts=ts or datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        rel_volume=Decimal("12.5"),
+        pct_change=Decimal("18.75"),
+        price=Decimal("3.42"),
+        float_shares=8_500_000,
+        news_present=True,
+        headline_count=4,
+        rank=rank,
+    )
+
+
+def _commit_counter(engine: Engine) -> list[int]:
+    """Return a single-element list whose value tracks engine-level commits."""
+    counter = [0]
+
+    @event.listens_for(engine, "commit")
+    def _on_commit(_conn: object) -> None:
+        counter[0] += 1
+
+    return counter
+
+
+# ----------------------------------------------------------- emit: per-kind
+
+
+def test_emit_picked_round_trips_pick_and_decision(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+) -> None:
+    """``emit('picked')`` writes both the Pick row and the linked decision."""
+    decision_ts = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    pick = _pick(ts=decision_ts)
+    writer.emit(
+        ScannerDecision(
+            kind="picked",
+            decision_ts=decision_ts,
+            ticker=pick.ticker,
+            pick=pick,
+            reason=None,
+            gap_start=None,
+            gap_end=None,
+        )
+    )
+
+    with session_factory() as session:
+        rows = session.execute(
+            select(ScannerDecisionRow).order_by(ScannerDecisionRow.id)
+        ).scalars().all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.kind is DecisionKind.PICKED
+        assert row.decision_ts == decision_ts
+        assert row.ticker == "ABCD"
+        assert row.pick_id is not None
+
+        pick_row = session.get(Pick, row.pick_id)
+        assert pick_row is not None
+        assert pick_row.ticker == "ABCD"
+        assert pick_row.ts == decision_ts
+        assert pick_row.rel_volume == Decimal("12.5")
+        assert pick_row.pct_change == Decimal("18.75")
+        assert pick_row.price == Decimal("3.42")
+        assert pick_row.float_shares == 8_500_000
+        assert pick_row.news_present is True
+        assert pick_row.headline_count == 4
+        assert pick_row.rank == 1
+
+
+def test_emit_stale_feed_round_trips(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+) -> None:
+    decision_ts = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    writer.emit(
+        ScannerDecision(
+            kind="stale_feed",
+            decision_ts=decision_ts,
+            ticker=None,
+            pick=None,
+            reason="feed stale by 7.0s",
+            gap_start=None,
+            gap_end=None,
+        )
+    )
+
+    with session_factory() as session:
+        rows = session.execute(select(ScannerDecisionRow)).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.kind is DecisionKind.STALE_FEED
+    assert row.decision_ts == decision_ts
+    assert row.ticker is None
+    assert row.pick_id is None
+    assert row.reason == "feed stale by 7.0s"
+    assert row.gap_start is None
+    assert row.gap_end is None
+
+
+def test_emit_feed_gap_round_trips(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+) -> None:
+    decision_ts = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    gap_start = datetime(2026, 5, 2, 14, 29, tzinfo=UTC)
+    gap_end = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    writer.emit(
+        ScannerDecision(
+            kind="feed_gap",
+            decision_ts=decision_ts,
+            ticker=None,
+            pick=None,
+            reason="upstream socket reset",
+            gap_start=gap_start,
+            gap_end=gap_end,
+        )
+    )
+
+    with session_factory() as session:
+        rows = session.execute(select(ScannerDecisionRow)).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.kind is DecisionKind.FEED_GAP
+    assert row.decision_ts == decision_ts
+    assert row.ticker is None
+    assert row.pick_id is None
+    assert row.reason == "upstream socket reset"
+    assert row.gap_start == gap_start
+    assert row.gap_end == gap_end
+
+
+def test_emit_picked_creates_independent_pick_per_call(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+) -> None:
+    """Same (ticker, ts) across emits => two Pick rows by design (no dedup)."""
+    decision_ts = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    for _ in range(2):
+        writer.emit(
+            ScannerDecision(
+                kind="picked",
+                decision_ts=decision_ts,
+                ticker="ABCD",
+                pick=_pick(ts=decision_ts),
+                reason=None,
+                gap_start=None,
+                gap_end=None,
+            )
+        )
+
+    with session_factory() as session:
+        pick_rows = session.execute(select(Pick)).scalars().all()
+        decision_rows = session.execute(select(ScannerDecisionRow)).scalars().all()
+    assert len(pick_rows) == 2
+    assert len(decision_rows) == 2
+    assert {r.pick_id for r in decision_rows} == {p.id for p in pick_rows}
+
+
+# -------------------------------------------------------------- record_scan
+
+
+def test_record_scan_single_commit_for_mixed_picks_and_rejections(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+    engine: Engine,
+) -> None:
+    """One scan tick = one transaction: ``record_scan`` commits exactly once."""
+    counter = _commit_counter(engine)
+    decision_ts = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    picks = [_pick(ticker="ABCD", ts=decision_ts, rank=1),
+             _pick(ticker="WXYZ", ts=decision_ts, rank=2)]
+    rejected = {
+        "AAAA": RejectionReason.REL_VOLUME,
+        "BBBB": RejectionReason.PCT_CHANGE,
+        "CCCC": RejectionReason.FLOAT_SIZE,
+    }
+
+    writer.record_scan(decision_ts=decision_ts, picks=picks, rejected=rejected)
+
+    assert counter[0] == 1, f"expected 1 commit, got {counter[0]}"
+
+    with session_factory() as session:
+        decisions = session.execute(
+            select(ScannerDecisionRow).order_by(ScannerDecisionRow.id)
+        ).scalars().all()
+        kinds = [(d.kind, d.ticker) for d in decisions]
+        assert (DecisionKind.PICKED, "ABCD") in kinds
+        assert (DecisionKind.PICKED, "WXYZ") in kinds
+        assert (DecisionKind.REJECTED, "AAAA") in kinds
+        assert (DecisionKind.REJECTED, "BBBB") in kinds
+        assert (DecisionKind.REJECTED, "CCCC") in kinds
+
+        rejected_rows = [d for d in decisions if d.kind is DecisionKind.REJECTED]
+        for r in rejected_rows:
+            assert r.ticker is not None
+            assert r.rejection_reason is rejected[r.ticker]
+            assert r.pick_id is None
+
+        pick_rows = session.execute(select(Pick)).scalars().all()
+        assert len(pick_rows) == 2
+
+
+def test_record_scan_empty_inputs_is_a_no_op(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+) -> None:
+    """Zero picks + zero rejected: doesn't crash, persists nothing."""
+    decision_ts = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+
+    writer.record_scan(decision_ts=decision_ts, picks=[], rejected={})
+
+    with session_factory() as session:
+        rows = session.execute(select(ScannerDecisionRow)).scalars().all()
+    assert rows == []
+
+
+def test_record_scan_rolls_back_on_partial_failure(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+) -> None:
+    """A constraint violation mid-tick rolls back ALL rows for that tick."""
+    decision_ts = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+    bad_pick = ScannerPick(
+        ticker="BAD",
+        ts=decision_ts,
+        rel_volume=Decimal("12.5"),
+        pct_change=Decimal("18.75"),
+        price=Decimal("3.42"),
+        float_shares=8_500_000,
+        news_present=True,
+        headline_count=4,
+        rank=1,
+    )
+    # Force NOT NULL violation by zeroing out a non-nullable field
+    # post-construction. ScannerPick is frozen, so we use object.__setattr__
+    # to make it dirty in a way that bypasses dataclass validation.
+    object.__setattr__(bad_pick, "ticker", None)
+
+    picks = [_pick(ticker="GOOD", ts=decision_ts, rank=1), bad_pick]
+    rejected = {"REJX": RejectionReason.REL_VOLUME}
+
+    with pytest.raises((IntegrityError, Exception)):
+        writer.record_scan(decision_ts=decision_ts, picks=picks, rejected=rejected)
+
+    with session_factory() as session:
+        pick_rows = session.execute(select(Pick)).scalars().all()
+        decision_rows = session.execute(select(ScannerDecisionRow)).scalars().all()
+    assert pick_rows == [], "GOOD Pick must be rolled back"
+    assert decision_rows == [], "REJX rejection must be rolled back"
+
+
+# -------------------------------------------------------- enum stability
+
+
+def test_record_scan_commit_p99_under_2s_on_populated_db(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+) -> None:
+    """Microbenchmark: record_scan p99 commit time < 2s with >=10k existing rows.
+
+    Not a hard perf gate -- if this regresses the answer is to revisit
+    (per #44 acceptance: "the answer is to revisit, not to add aiosqlite
+    preemptively").
+    """
+    import time
+
+    decision_ts = datetime(2026, 5, 2, 14, 30, tzinfo=UTC)
+
+    # Seed >= 10k existing scanner_decisions rows via raw INSERT for speed.
+    seed_ts = "2026-04-01T14:30:00+00:00"
+    with session_factory() as session, session.begin():
+        conn = session.connection()
+        conn.exec_driver_sql(
+            "INSERT INTO scanner_decisions "
+            "(kind, decision_ts, ticker, pick_id, reason, "
+            "gap_start, gap_end, rejection_reason) "
+            "VALUES "
+            + ",".join(
+                f"('rejected', '{seed_ts}', 'T{i:05d}', NULL, NULL, NULL, NULL, "
+                "'rel_volume')"
+                for i in range(10_000)
+            ),
+        )
+
+    picks = [_pick(ticker=f"P{i:03d}", ts=decision_ts, rank=i + 1) for i in range(5)]
+    rejected = {f"R{i:03d}": RejectionReason.REL_VOLUME for i in range(20)}
+
+    samples: list[float] = []
+    for _ in range(20):
+        start = time.perf_counter()
+        writer.record_scan(decision_ts=decision_ts, picks=picks, rejected=rejected)
+        samples.append(time.perf_counter() - start)
+
+    p99 = sorted(samples)[int(len(samples) * 0.99) - 1]
+    assert p99 < 2.0, (
+        f"record_scan p99 over 2s budget: {p99:.3f}s on 10k-row DB. "
+        "If this regresses, revisit per #44 acceptance -- do not add aiosqlite preemptively."
+    )
+
+
+def test_rejection_reason_values_match_51_contract() -> None:
+    """The seven RejectionReason values are the #51 contract; rename = migration.
+
+    Locked-in literals (order matches the Scanner.scan AND-chain).
+    """
+    expected = [
+        "no_snapshot",
+        "missing_baseline",
+        "missing_float",
+        "rel_volume",
+        "pct_change",
+        "price_band",
+        "float_size",
+    ]
+    actual = [r.value for r in RejectionReason]
+    assert actual == expected, (
+        f"RejectionReason vocabulary drifted: expected {expected}, got {actual}. "
+        "This is the #51 contract; renaming requires a migration."
+    )


### PR DESCRIPTION
## Summary

Concrete `DecisionSink` (Phase 2 — Atom A5, #44) backed by the SQLAlchemy session factory from #43, plus the deferred P2 review item from PR #54: schema-level CHECK constraints on `scanner_decisions` enforcing the `kind` → field-population invariants.

`JournalWriter` exposes two surfaces:

- `emit(decision)` — the A3 hot path. Per-call commit (one row per transaction).
- `record_scan(decision_ts, picks, rejected)` — batch API. One transaction per scan tick, atomic on partial failure.

A3's loop continues to call `emit()` N times per tick (Protocol seam stays narrow; existing A3 tests keep using `FakeDecisionSink`). The end-to-end smoke test exercises the wiring with a real `JournalWriter` against an in-memory engine.

## Atomicity scope today (and after #51)

A3 currently emits per-pick. A crash mid-tick can leave a partial picked-set on disk — **under-recording, not inconsistency**:

- The three current kinds are structurally near-atomic. `stale_feed` and `feed_gap` each fire alone (no picks); picks fire alone (no `stale_feed`). The only intra-tick split is "pick #2 vs pick #3 of the same tick."
- A3 is stateless across ticks; the next tick runs fresh.

When #51 lands the fourth `rejected` kind, picks + rejections need true tick-atomicity (committing picks but not rejections would systematically overstate scanner precision). #51's scope includes migrating A3's loop from N×`emit()` to a single `record_scan()` per tick. Documented inline in `writer.py`'s module docstring.

The `record_scan` signature will likely become `(decision_ts, result: ScanResult)` once #51 ships its `ScannerRejection` dataclass; this PR intentionally does not pre-introduce that shape.

## CHECK constraints (deferred from #54 P2)

Five biconditional invariants enforced at the schema level via migration `0002_scanner_decisions_check_constraints.py` (Alembic batch mode — SQLite cannot `ALTER TABLE ADD CHECK` directly):

| Constraint | Condition |
|---|---|
| `ck_scanner_decisions_picked_pick_id` | `(kind = 'picked')   = (pick_id IS NOT NULL)` |
| `ck_scanner_decisions_rejected_reason` | `(kind = 'rejected') = (rejection_reason IS NOT NULL)` |
| `ck_scanner_decisions_feed_gap_start` | `(kind = 'feed_gap') = (gap_start IS NOT NULL)` |
| `ck_scanner_decisions_feed_gap_end` | `(kind = 'feed_gap') = (gap_end IS NOT NULL)` |
| `ck_scanner_decisions_ticker_required` | `kind IN ('stale_feed', 'feed_gap') OR ticker IS NOT NULL` |

The same constraints are declared on the SQLAlchemy model so `Base.metadata.create_all` (used by unit tests) produces the schema as `alembic upgrade head`.

While re-running the journal suite against the constraint-aware schema, an existing test in `test_journal_migrations.py` was constructing a `picked` row without a `pick_id` — logically malformed, accepted by the pre-CHECK schema. Fixed to seed a real `Pick` first; mentioned only because reviewers will see that file in the diff.

## What reviewers should pay attention to

- `writer.py` does not issue `BEGIN IMMEDIATE` per call — the engine-level `begin` listener from #43 covers that. Cross-reference is in the writer's module docstring.
- `record_scan` uses `with session.begin():` so the BEGIN/COMMIT pair fires unconditionally (including the empty-input case), keeping "one tick = one transaction" a property of every call.
- The microbenchmark on populated-DB commit p99 is informational, not a hard perf gate (per #44 acceptance: if it regresses, revisit — don't add aiosqlite preemptively).

## Verification

- 231 tests pass (206 prior + 25 new).
- `mypy --strict`: clean across 76 source files.
- `ruff check`: all checks passed.
- `record_scan` p99 < 2s on 10k-row populated DB confirmed.

Closes #44.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)