### PR TITLE
feat(journal): hand-curated ground-truth loader (#45)

### DIFF
--- a/ground_truth/2026-05-01.json
+++ b/ground_truth/2026-05-01.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ticker": "AVTX",
+    "direction": "long",
+    "time_called_out": "07:32",
+    "notes": "small float biotech, called as a clean long off the FDA catalyst on the morning recap"
+  },
+  {
+    "ticker": "MSTR",
+    "direction": "long",
+    "time_called_out": "09:35",
+    "notes": "premarket gapper traded long off the opening range; sized down for the higher-priced name"
+  }
+]

--- a/src/ross_trading/journal/ground_truth.py
+++ b/src/ross_trading/journal/ground_truth.py
@@ -1,0 +1,176 @@
+"""Hand-curated ground-truth loader for the Phase 2 recall metric.
+
+Phase 2 -- Atom A6 (#45). Per Decision D3 (#37), the source of truth for
+"what would Cameron have traded today" is a hand-curated JSON file per
+trading day, committed to the repo at ``ground_truth/YYYY-MM-DD.json``.
+A7 (#46) joins the records returned here against the scanner journal
+to compute the 70% recall gate that closes Phase 2.
+
+Convention -- include only **actively-called** tickers. Tickers Cameron
+mentioned, watched, or rejected during the recap are *excluded*. The file
+is the oracle of what would have been traded, not a transcript.
+
+Per-file shape -- a JSON array of records. Schema:
+
+* ``ticker`` (required) -- non-empty string. Stripped + upper-cased on
+  load (curators sometimes write lowercase or with stray whitespace), so
+  matching against ``ScannerPick.ticker`` is consistent with the
+  convention used by ``Headline.dedup_key`` upstream.
+* ``direction`` (required) -- the literal string ``"long"``. Single-valued
+  today but kept explicit so a future short-bias variant is a schema
+  bump, not a silent reinterpretation. Case-strict.
+* ``time_called_out`` (optional) -- ``"HH:MM"`` ET, validated by format
+  only (no zone math is applied here -- A7 does any window logic). Omit
+  when the time is unknown.
+* ``notes`` (optional) -- free text.
+
+The schema is closed: any unknown key in a record is a loud error, so a
+curator typo (``"note"`` for ``"notes"``) surfaces immediately rather
+than silently dropping data. Adding a real new field requires bumping
+this loader and the curated files together.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, time
+from pathlib import Path
+from typing import Literal
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFAULT_GROUND_TRUTH_DIR = _REPO_ROOT / "ground_truth"
+
+_REQUIRED_FIELDS: frozenset[str] = frozenset({"ticker", "direction"})
+_OPTIONAL_FIELDS: frozenset[str] = frozenset({"time_called_out", "notes"})
+_ALLOWED_FIELDS: frozenset[str] = _REQUIRED_FIELDS | _OPTIONAL_FIELDS
+
+# Strict ``HH:MM`` 24-hour clock. ``time.fromisoformat`` would accept
+# ``07:30:15`` and other ISO variants -- the curated oracle is meant to be
+# uniform, so we reject anything that is not exactly two digits, colon,
+# two digits.
+_HHMM_RE = re.compile(r"\A([01]\d|2[0-3]):[0-5]\d\Z")
+
+
+class GroundTruthError(ValueError):
+    """Raised when a ground-truth file is malformed or violates the schema."""
+
+
+@dataclass(frozen=True, slots=True)
+class GroundTruthEntry:
+    """A single hand-curated "would have traded" record for one ticker."""
+
+    ticker: str
+    direction: Literal["long"]
+    time_called_out: time | None
+    notes: str | None
+
+
+def load_ground_truth(
+    day: date,
+    *,
+    root: Path | None = None,
+) -> list[GroundTruthEntry]:
+    """Load curated ground-truth entries for *day*.
+
+    *root* defaults to the repo's ``ground_truth/`` directory; tests
+    inject a ``tmp_path``. Raises :class:`FileNotFoundError` when the
+    day's file does not exist and :class:`GroundTruthError` (a
+    ``ValueError`` subclass) on every other malformed-input mode.
+    """
+    base = root if root is not None else _DEFAULT_GROUND_TRUTH_DIR
+    path = base / f"{day.isoformat()}.json"
+    raw = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = f"{path.name}: malformed JSON ({exc.msg} at line {exc.lineno})"
+        raise GroundTruthError(msg) from exc
+    if not isinstance(payload, list):
+        msg = (
+            f"{path.name}: top-level value must be a JSON array, "
+            f"got {type(payload).__name__}"
+        )
+        raise GroundTruthError(msg)
+
+    entries: list[GroundTruthEntry] = []
+    seen: set[str] = set()
+    for index, item in enumerate(payload):
+        entry = _parse_entry(item, index=index)
+        if entry.ticker in seen:
+            msg = f"{path.name}: duplicate ticker {entry.ticker!r} at index {index}"
+            raise GroundTruthError(msg)
+        seen.add(entry.ticker)
+        entries.append(entry)
+    return entries
+
+
+def _parse_entry(item: object, *, index: int) -> GroundTruthEntry:
+    if not isinstance(item, dict):
+        msg = f"index {index}: each record must be a JSON object, got {type(item).__name__}"
+        raise GroundTruthError(msg)
+
+    keys = set(item.keys())
+    missing = _REQUIRED_FIELDS - keys
+    if missing:
+        msg = f"index {index}: missing required field(s) {sorted(missing)}"
+        raise GroundTruthError(msg)
+    unknown = keys - _ALLOWED_FIELDS
+    if unknown:
+        msg = f"index {index}: unknown field(s) {sorted(unknown)}"
+        raise GroundTruthError(msg)
+
+    ticker = _parse_ticker(item["ticker"], index=index)
+    direction = _parse_direction(item["direction"], index=index)
+    time_called_out = (
+        _parse_time(item["time_called_out"], index=index)
+        if "time_called_out" in item
+        else None
+    )
+    notes = _parse_notes(item["notes"], index=index) if "notes" in item else None
+    return GroundTruthEntry(
+        ticker=ticker,
+        direction=direction,
+        time_called_out=time_called_out,
+        notes=notes,
+    )
+
+
+def _parse_ticker(value: object, *, index: int) -> str:
+    if not isinstance(value, str):
+        msg = f"index {index}: ticker must be a string, got {type(value).__name__}"
+        raise GroundTruthError(msg)
+    cleaned = value.strip().upper()
+    if not cleaned:
+        msg = f"index {index}: ticker must be non-empty"
+        raise GroundTruthError(msg)
+    return cleaned
+
+
+def _parse_direction(value: object, *, index: int) -> Literal["long"]:
+    if value != "long":
+        msg = (
+            f"index {index}: direction must be the literal string 'long' "
+            f"(case-strict), got {value!r}"
+        )
+        raise GroundTruthError(msg)
+    return "long"
+
+
+def _parse_time(value: object, *, index: int) -> time:
+    if not isinstance(value, str) or not _HHMM_RE.fullmatch(value):
+        msg = (
+            f"index {index}: time_called_out must be a 'HH:MM' 24-hour string, "
+            f"got {value!r}"
+        )
+        raise GroundTruthError(msg)
+    hours, minutes = value.split(":")
+    return time(int(hours), int(minutes))
+
+
+def _parse_notes(value: object, *, index: int) -> str:
+    if not isinstance(value, str):
+        msg = f"index {index}: notes must be a string, got {type(value).__name__}"
+        raise GroundTruthError(msg)
+    return value

--- a/tests/unit/test_ground_truth.py
+++ b/tests/unit/test_ground_truth.py
@@ -1,0 +1,240 @@
+"""Atom A6 (#45) -- ground-truth loader unit tests.
+
+Reads hand-curated daily JSON files from ``ground_truth/YYYY-MM-DD.json``
+and returns typed records. Per Decision D3 (#37), this is the oracle of
+"what would Cameron have traded today" -- A7 (#46) joins this output
+against the journal to compute the 70% recall metric that gates Phase 2.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, time
+from pathlib import Path
+
+import pytest
+
+from ross_trading.journal.ground_truth import (
+    GroundTruthEntry,
+    GroundTruthError,
+    load_ground_truth,
+)
+
+
+def _write(root: Path, day: date, payload: object) -> None:
+    """Write *payload* as JSON for *day* under *root*/."""
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{day.isoformat()}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_happy_path_returns_typed_entries(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(
+        tmp_path,
+        day,
+        [
+            {
+                "ticker": "TSLA",
+                "direction": "long",
+                "time_called_out": "07:32",
+                "notes": "called on the recap as a clean long off the news catalyst",
+            },
+            {
+                "ticker": "AVTX",
+                "direction": "long",
+            },
+        ],
+    )
+
+    entries = load_ground_truth(day, root=tmp_path)
+
+    assert entries == [
+        GroundTruthEntry(
+            ticker="TSLA",
+            direction="long",
+            time_called_out=time(7, 32),
+            notes="called on the recap as a clean long off the news catalyst",
+        ),
+        GroundTruthEntry(
+            ticker="AVTX",
+            direction="long",
+            time_called_out=None,
+            notes=None,
+        ),
+    ]
+
+
+def test_missing_file_raises_file_not_found_error(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_ground_truth(date(2026, 5, 1), root=tmp_path)
+
+
+def test_malformed_json_raises_ground_truth_error(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / f"{day.isoformat()}.json").write_text("not json {", encoding="utf-8")
+
+    with pytest.raises(GroundTruthError):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_top_level_must_be_a_list(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, {"ticker": "TSLA", "direction": "long"})
+
+    with pytest.raises(GroundTruthError, match="top-level"):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_empty_array_returns_empty_list(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, [])
+
+    assert load_ground_truth(day, root=tmp_path) == []
+
+
+def test_duplicate_ticker_within_a_file_rejected(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(
+        tmp_path,
+        day,
+        [
+            {"ticker": "TSLA", "direction": "long"},
+            {"ticker": "tsla", "direction": "long"},
+        ],
+    )
+
+    with pytest.raises(GroundTruthError, match="duplicate"):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_lowercase_ticker_normalized_to_uppercase(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, [{"ticker": "tsla", "direction": "long"}])
+
+    [entry] = load_ground_truth(day, root=tmp_path)
+
+    assert entry.ticker == "TSLA"
+
+
+def test_ticker_whitespace_stripped(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, [{"ticker": " tsla  ", "direction": "long"}])
+
+    [entry] = load_ground_truth(day, root=tmp_path)
+
+    assert entry.ticker == "TSLA"
+
+
+def test_empty_ticker_rejected(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, [{"ticker": "", "direction": "long"}])
+
+    with pytest.raises(GroundTruthError, match="ticker"):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_whitespace_only_ticker_rejected(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, [{"ticker": "   ", "direction": "long"}])
+
+    with pytest.raises(GroundTruthError, match="ticker"):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_missing_required_field_rejected(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, [{"ticker": "TSLA"}])
+
+    with pytest.raises(GroundTruthError, match="direction"):
+        load_ground_truth(day, root=tmp_path)
+
+
+@pytest.mark.parametrize("bad_direction", ["short", "Long", "LONG", "buy", ""])
+def test_direction_other_than_long_rejected(
+    tmp_path: Path,
+    bad_direction: str,
+) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, [{"ticker": "TSLA", "direction": bad_direction}])
+
+    with pytest.raises(GroundTruthError, match="direction"):
+        load_ground_truth(day, root=tmp_path)
+
+
+@pytest.mark.parametrize("bad_time", ["7:30", "25:00", "07:30:15", "07:60", "noon"])
+def test_invalid_time_called_out_rejected(
+    tmp_path: Path,
+    bad_time: str,
+) -> None:
+    day = date(2026, 5, 1)
+    _write(
+        tmp_path,
+        day,
+        [{"ticker": "TSLA", "direction": "long", "time_called_out": bad_time}],
+    )
+
+    with pytest.raises(GroundTruthError, match="time_called_out"):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_time_called_out_zero_padded_parses(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(
+        tmp_path,
+        day,
+        [{"ticker": "TSLA", "direction": "long", "time_called_out": "07:30"}],
+    )
+
+    [entry] = load_ground_truth(day, root=tmp_path)
+
+    assert entry.time_called_out == time(7, 30)
+
+
+def test_unknown_field_rejected(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(
+        tmp_path,
+        day,
+        [{"ticker": "TSLA", "direction": "long", "confidence": 0.9}],
+    )
+
+    with pytest.raises(GroundTruthError, match="unknown field"):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_notes_field_must_be_string_when_present(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(
+        tmp_path,
+        day,
+        [{"ticker": "TSLA", "direction": "long", "notes": 42}],
+    )
+
+    with pytest.raises(GroundTruthError, match="notes"):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_record_must_be_object(tmp_path: Path) -> None:
+    day = date(2026, 5, 1)
+    _write(tmp_path, day, ["TSLA"])
+
+    with pytest.raises(GroundTruthError, match="JSON object"):
+        load_ground_truth(day, root=tmp_path)
+
+
+def test_default_root_is_repo_ground_truth_directory() -> None:
+    """Sanity-check that omitting *root* targets the repo's ground_truth/ dir.
+
+    Asserts via the exception's ``filename`` attribute, which is platform-
+    independent (unlike ``str(exc)`` whose Errno prefix is OS-specific).
+    """
+    bogus_day = date(1990, 1, 2)
+    with pytest.raises(FileNotFoundError) as exc:
+        load_ground_truth(bogus_day)
+
+    assert exc.value.filename is not None
+    target = Path(exc.value.filename)
+    assert target.parent.name == "ground_truth"
+    assert target.name == f"{bogus_day.isoformat()}.json"


### PR DESCRIPTION
## Summary

Phase 2 — Atom A6 (#45). Lands the oracle side of the Phase 2 recall metric: a per-day JSON file at `ground_truth/YYYY-MM-DD.json` listing the tickers Cameron actively called out, parsed into typed `GroundTruthEntry` records by a single function `load_ground_truth(day, root=...)`. Decision **D3** (#37) is the choice this PR materializes: hand-curated daily JSON, one file per day, in the repo (under `ground_truth/` rather than `data/` because the existing `.gitignore` rule `/data/` would silently swallow the path).

A7 (#46) is the OTHER side of this — it joins these records against the scanner journal (A4/A5) to compute the 70% recall gate that closes Phase 2. A6 is intentionally minimal: read JSON from disk, validate, return typed records. No DB, no async, no caching, no comparison logic.

## What's in here

**Loader** (`src/ross_trading/journal/ground_truth.py`)
- `GroundTruthEntry` — frozen, slotted dataclass mirroring the four-field schema. `direction` is `Literal["long"]` so a future short-bias variant is a schema bump, not a silent reinterpretation.
- `GroundTruthError` — `ValueError` subclass for every malformed-input mode except missing file (which surfaces as `FileNotFoundError` with the path attached, so a curator can debug a typo'd date locally).
- `load_ground_truth(day, *, root=None)` — single-date load. `root` defaults to the repo's `ground_truth/` directory; tests inject `tmp_path`.

**Closed schema, fail loud.** Unknown keys raise `GroundTruthError` so a curator typo like `"note"` for `"notes"` surfaces immediately rather than silently dropping data. Adding a real new field requires bumping the loader and the curated files together — appropriate for a hand-curated oracle.

| Field | Required | Notes |
|---|---|---|
| `ticker` | yes | Stripped + upper-cased on load (curators sometimes write lowercase or with stray whitespace; this mirrors the upper-casing convention used by `Headline.dedup_key` upstream). Empty/whitespace-only rejected. |
| `direction` | yes | Literal string `"long"`. Case-strict — `"Long"`, `"LONG"`, `"short"`, `"buy"` all rejected. |
| `time_called_out` | no | Strict `HH:MM` 24h. `time.fromisoformat` would accept `07:30:15` and other ISO variants — the curated oracle is meant to be uniform, so an explicit regex enforces exactly two digits, colon, two digits. |
| `notes` | no | Free text; rejected if present and non-string. |

**Within-file dedup.** Duplicate tickers in a single file are a curator mistake (likely a copy-paste); rejected with the index of the offender. Cross-file deduplication is A7's problem, not A6's.

**Whitespace in tickers** is stripped (parallel to the case-normalization rule). Calling this out because the issue body specifies case-normalization but is silent on whitespace; treating both as common curator slips felt more useful than rejecting one and normalizing the other.

**Example file** (`ground_truth/2026-05-01.json`)
- Two entries with all four fields populated, real curated shape (small float biotech with a morning recap call, plus a higher-priced premarket gapper). Round-trips through `load_ground_truth(date(2026, 5, 1))` at the default root. Lands so the directory exists in git AND a future reader sees the format without reading the module docstring.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Happy path returns parsed list | `test_happy_path_returns_typed_entries` |
| Missing file raises `FileNotFoundError` | `test_missing_file_raises_file_not_found_error` |
| Malformed JSON raises `GroundTruthError` | `test_malformed_json_raises_ground_truth_error` |
| Empty array returns `[]`, not an error | `test_empty_array_returns_empty_list` |
| Duplicate tickers in a file rejected | `test_duplicate_ticker_within_a_file_rejected` |
| Lowercase tickers normalized to uppercase | `test_lowercase_ticker_normalized_to_uppercase` |
| `direction` other than `"long"` rejected (incl. `"Long"`, `"LONG"`) | `test_direction_other_than_long_rejected` (parametrized over 5 cases) |
| `time_called_out` rejects `7:30`, `25:00`, `07:30:15`, `07:60`, `noon` | `test_invalid_time_called_out_rejected` (parametrized over 5 cases) |
| `time_called_out` `07:30` parses to `time(7, 30)` | `test_time_called_out_zero_padded_parses` |
| Default `root` resolves to repo `ground_truth/` | `test_default_root_is_repo_ground_truth_directory` |
| `mypy --strict` clean | full suite: 78 source files, 0 issues |
| `ruff check` clean | all checks passed |

## Tests

26 new tests, all green; 257/257 in the full suite (was 231 before this PR).

## Out of scope

- Comparison against the journal — that's A7 (#46).
- Time-window matching — D3 explicitly defers this; ticker-only matching for the initial 70% recall gate.
- Multi-day loading, CLI, caching — single-date load only.
- Anything DB-related — the loader returns plain `GroundTruthEntry` records; A7 will materialize the comparison.

## Verification

- 257 tests pass (231 prior + 26 new).
- `mypy --strict`: clean across 78 source files.
- `ruff check`: all checks passed.
- Example file round-trips through `load_ground_truth(date(2026, 5, 1))` at default root.

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)