### PR TITLE
feat(journal): daily comparison report for Phase 2 recall gate (#46)

### DIFF
--- a/src/ross_trading/journal/report.py
+++ b/src/ross_trading/journal/report.py
@@ -1,0 +1,279 @@
+"""Phase 2 daily comparison report -- recall metric for the 70% gate.
+
+Atom A7 (#46). Joins the scanner journal (A4/A5) with the hand-curated
+ground-truth oracle (A6) for one trading day and emits a deterministic
+markdown report under ``reports/YYYY-MM-DD.md``. Per Decision D3 (#37),
+matching is ticker-only -- time-window matching is deferred.
+
+The "scanner set" is sourced from ``ScannerDecision`` rows whose ``kind``
+is ``PICKED``, joined to the linked ``Pick`` row -- *not* from
+``WatchlistEntry``. ``WatchlistEntry`` is open-ended membership
+(``added_at`` / ``removed_at``) and belongs to the Phase 3 graduation
+surface; the recall metric here is "did the scanner pick what Cameron
+called out", which is the per-day picked-set.
+
+The day boundary is America/New_York (matches the scanner's
+``is_market_hours`` window in :mod:`ross_trading.core.clock`). Picks
+stored in tz-aware UTC are filtered against ``[YYYY-MM-DD 00:00 ET,
++1d 00:00 ET)`` translated to UTC. DST is handled by zoneinfo.
+
+Pick.ticker is not normalized at the model layer today (a follow-up
+issue tracks enforcing ``.upper()`` at ``Pick.__init__``); this module
+defensively upper-cases the journal side of the join so a stray
+lowercase row doesn't silently miss against the ground truth, which A6
+already upper-cases on load.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select
+
+from ross_trading.journal.engine import (
+    create_journal_engine,
+    create_session_factory,
+)
+from ross_trading.journal.ground_truth import load_ground_truth
+from ross_trading.journal.models import DecisionKind, Pick
+from ross_trading.journal.models import ScannerDecision as ScannerDecisionRow
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+_NY_TZ = ZoneInfo("America/New_York")
+_DEFAULT_DB_URL = "sqlite:///journal.sqlite"
+_DEFAULT_REPORTS_DIR = Path("reports")
+
+
+@dataclass(frozen=True, slots=True)
+class DailyReport:
+    """Single-day comparison of scanner picks vs Cameron's ground-truth."""
+
+    day: date
+    cameron: frozenset[str]
+    scanner: frozenset[str]
+    matched: frozenset[str]
+    missed: frozenset[str]
+    extra: frozenset[str]
+
+    @classmethod
+    def from_sets(
+        cls,
+        *,
+        day: date,
+        cameron: frozenset[str],
+        scanner: frozenset[str],
+    ) -> DailyReport:
+        """Derive matched / missed / extra from the two ticker sets."""
+        return cls(
+            day=day,
+            cameron=cameron,
+            scanner=scanner,
+            matched=cameron & scanner,
+            missed=cameron - scanner,
+            extra=scanner - cameron,
+        )
+
+    @property
+    def recall(self) -> Decimal:
+        # 0/0 -> 0 by convention so the report still renders on the
+        # "ground truth missing entries" corner without raising.
+        if not self.cameron:
+            return Decimal(0)
+        return Decimal(len(self.matched)) / Decimal(len(self.cameron))
+
+    @property
+    def precision(self) -> Decimal:
+        # 0/0 -> 0 by convention so the report still renders on a
+        # quiet scanner day without raising.
+        if not self.scanner:
+            return Decimal(0)
+        return Decimal(len(self.matched)) / Decimal(len(self.scanner))
+
+
+def _et_day_bounds_utc(day: date) -> tuple[datetime, datetime]:
+    """Return ``[start, end)`` in UTC for *day* interpreted as ET wall-clock.
+
+    DST handled by zoneinfo: a 23-hour or 25-hour day surfaces as a UTC
+    range whose width matches the underlying ET span, not a fixed 24h.
+    """
+    start_et = datetime.combine(day, datetime.min.time(), tzinfo=_NY_TZ)
+    end_et = datetime.combine(day + timedelta(days=1), datetime.min.time(), tzinfo=_NY_TZ)
+    return start_et.astimezone(ZoneInfo("UTC")), end_et.astimezone(ZoneInfo("UTC"))
+
+
+def build_daily_report(
+    day: date,
+    *,
+    session_factory: sessionmaker[Session],
+    ground_truth_root: Path | None = None,
+) -> DailyReport:
+    """Compute the Phase 2 daily comparison for *day*.
+
+    Reads the scanner picked-set from the journal (``ScannerDecision``
+    rows with ``kind=PICKED`` joined to ``Pick``, filtered to *day* in
+    ET wall-clock) and the ground-truth set from
+    :func:`load_ground_truth`. Returns a typed result; rendering and
+    persistence are separate concerns.
+
+    Raises :class:`FileNotFoundError` when the ground-truth file for
+    *day* is missing (surfaced from the loader unmodified, so a curator
+    typo'd date debugs cleanly).
+    """
+    start_utc, end_utc = _et_day_bounds_utc(day)
+
+    with session_factory() as session:
+        rows = session.execute(
+            select(Pick.ticker)
+            .join(ScannerDecisionRow, ScannerDecisionRow.pick_id == Pick.id)
+            .where(
+                ScannerDecisionRow.kind == DecisionKind.PICKED,
+                ScannerDecisionRow.decision_ts >= start_utc,
+                ScannerDecisionRow.decision_ts < end_utc,
+            )
+        ).scalars().all()
+    scanner = frozenset(t.upper() for t in rows)
+
+    cameron = frozenset(
+        e.ticker for e in load_ground_truth(day, root=ground_truth_root)
+    )
+
+    return DailyReport.from_sets(day=day, cameron=cameron, scanner=scanner)
+
+
+def _format_pct(value: Decimal) -> str:
+    """Format *value* (in 0..1) as a one-decimal percentage, e.g. ``72.7%``."""
+    pct = (value * Decimal(100)).quantize(Decimal("0.1"))
+    return f"{pct}%"
+
+
+def render_report(report: DailyReport) -> str:
+    """Render *report* as the deterministic markdown audit artifact.
+
+    Section order is fixed (Definitions -> Summary -> Matched -> Missed
+    -> Extra). Tickers within each ticker-list section are sorted A-Z.
+    Empty sections render their heading plus ``_(none)_`` so the report
+    shape is uniform across days. The body contains no datetime stamps;
+    the only date is ``report.day`` in the title.
+    """
+    cameron_n = len(report.cameron)
+    scanner_n = len(report.scanner)
+    matched_n = len(report.matched)
+    recall = _format_pct(report.recall)
+    precision = _format_pct(report.precision)
+
+    lines: list[str] = [
+        f"# Phase 2 daily comparison -- {report.day.isoformat()}",
+        "",
+        "## Definitions",
+        "- Recall = |Cameron ∩ scanner| / |Cameron|  (gating, target >= 70%)",
+        "- Precision = |Cameron ∩ scanner| / |scanner|  (reported, not gating)",
+        "",
+        "## Summary",
+        f"- Cameron called: {cameron_n} tickers",
+        f"- Scanner picked: {scanner_n} tickers",
+        f"- Matched: {matched_n}",
+        f"- Recall: {matched_n}/{cameron_n} = {recall}",
+        f"- Precision: {matched_n}/{scanner_n} = {precision}",
+        "",
+    ]
+    for heading, tickers in (
+        ("Matched", report.matched),
+        ("Missed", report.missed),
+        ("Extra", report.extra),
+    ):
+        lines.append(f"## {heading}")
+        if not tickers:
+            lines.append("_(none)_")
+        else:
+            for ticker in sorted(tickers):
+                lines.append(f"- {ticker}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry: write ``reports/YYYY-MM-DD.md`` for the requested day.
+
+    Re-runs are idempotent -- the file is overwritten in place so the
+    gate stays cheap to re-evaluate as the journal and ground truth
+    grow. Stdout surfaces the written path plus a one-line summary
+    suitable for shells and CI.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m ross_trading.journal.report",
+        description=(
+            "Phase 2 daily comparison report -- joins the scanner journal "
+            "with hand-curated ground truth and writes a deterministic "
+            "markdown summary."
+        ),
+    )
+    parser.add_argument(
+        "--date",
+        required=True,
+        type=date.fromisoformat,
+        help="Trading day (ET) to report on, in YYYY-MM-DD form.",
+    )
+    parser.add_argument(
+        "--db",
+        default=_DEFAULT_DB_URL,
+        help=(
+            "SQLAlchemy URL for the scanner journal "
+            f"(default: {_DEFAULT_DB_URL})."
+        ),
+    )
+    parser.add_argument(
+        "--ground-truth-root",
+        type=Path,
+        default=None,
+        help=(
+            "Override the ground-truth directory root. "
+            "Defaults to the repo's ground_truth/ directory."
+        ),
+    )
+    parser.add_argument(
+        "--reports-dir",
+        type=Path,
+        default=_DEFAULT_REPORTS_DIR,
+        help=f"Directory to write the report into (default: {_DEFAULT_REPORTS_DIR}).",
+    )
+    args = parser.parse_args(argv)
+
+    engine = create_journal_engine(args.db)
+    try:
+        session_factory = create_session_factory(engine)
+        report = build_daily_report(
+            args.date,
+            session_factory=session_factory,
+            ground_truth_root=args.ground_truth_root,
+        )
+    finally:
+        engine.dispose()
+
+    args.reports_dir.mkdir(parents=True, exist_ok=True)
+    out_path = args.reports_dir / f"{args.date.isoformat()}.md"
+    out_path.write_text(render_report(report), encoding="utf-8")
+
+    cameron_n = len(report.cameron)
+    scanner_n = len(report.scanner)
+    matched_n = len(report.matched)
+    print(f"Wrote {out_path}")
+    print(
+        f"Recall: {matched_n}/{cameron_n} = {_format_pct(report.recall)} | "
+        f"Precision: {matched_n}/{scanner_n} = {_format_pct(report.precision)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin shim
+    raise SystemExit(main())

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1,0 +1,494 @@
+"""Atom A7 (#46) -- daily comparison report unit tests.
+
+Joins the scanner journal (A4/A5) with the hand-curated ground truth
+(A6) for one trading day and computes the recall metric that gates
+Phase 2 closure (>= 70%). Per Decision D3 (#37), matching is
+ticker-only -- no time-window joins.
+
+Test ordering follows superpowers:test-driven-development: one
+acceptance criterion = one red-green cycle. The metric math is
+asserted against a synthetic ``DailyReport`` first; the database
+integration tests come after.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ross_trading.journal.engine import (
+    create_journal_engine,
+    create_session_factory,
+)
+from ross_trading.journal.models import Base
+from ross_trading.journal.report import (
+    DailyReport,
+    build_daily_report,
+    main,
+    render_report,
+)
+from ross_trading.journal.writer import JournalWriter
+from ross_trading.scanner.decisions import ScannerDecision
+from ross_trading.scanner.types import ScannerPick
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+# --------------------------------------------------------------------- helpers
+
+
+def _report(
+    *,
+    cameron: frozenset[str],
+    scanner: frozenset[str],
+) -> DailyReport:
+    """Build a DailyReport from raw cameron/scanner sets.
+
+    Lets each metric test focus on the property under test rather
+    than re-deriving matched / missed / extra in every case.
+    """
+    return DailyReport.from_sets(
+        day=date(2026, 5, 1),
+        cameron=cameron,
+        scanner=scanner,
+    )
+
+
+def _pick(
+    *,
+    ticker: str,
+    ts: datetime,
+    rank: int = 1,
+) -> ScannerPick:
+    return ScannerPick(
+        ticker=ticker,
+        ts=ts,
+        rel_volume=Decimal("12.5"),
+        pct_change=Decimal("18.75"),
+        price=Decimal("3.42"),
+        float_shares=8_500_000,
+        news_present=True,
+        headline_count=4,
+        rank=rank,
+    )
+
+
+def _emit_picked(writer: JournalWriter, *, ticker: str, ts: datetime) -> None:
+    writer.emit(
+        ScannerDecision(
+            kind="picked",
+            decision_ts=ts,
+            ticker=ticker,
+            pick=_pick(ticker=ticker, ts=ts),
+            reason=None,
+            gap_start=None,
+            gap_end=None,
+        )
+    )
+
+
+def _write_ground_truth(root: Path, day: date, tickers: list[str]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    payload = [{"ticker": t, "direction": "long"} for t in tickers]
+    (root / f"{day.isoformat()}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+# --------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def engine() -> Iterator[Engine]:
+    eng = create_journal_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    try:
+        yield eng
+    finally:
+        eng.dispose()
+
+
+@pytest.fixture
+def session_factory(engine: Engine) -> sessionmaker[Session]:
+    return create_session_factory(engine)
+
+
+@pytest.fixture
+def writer(session_factory: sessionmaker[Session]) -> JournalWriter:
+    return JournalWriter(session_factory)
+
+
+def test_recall_is_matched_over_cameron_when_cameron_non_empty() -> None:
+    """recall = |Cameron ∩ scanner| / |Cameron| -- the gating metric."""
+    report = _report(
+        cameron=frozenset({"AAAA", "BBBB", "CCCC", "DDDD"}),
+        scanner=frozenset({"AAAA", "BBBB", "XXXX"}),
+    )
+    assert report.recall == Decimal("0.5"), (
+        f"expected 2 of 4 = 0.5, got {report.recall}"
+    )
+
+
+def test_precision_is_matched_over_scanner_when_scanner_non_empty() -> None:
+    """precision = |Cameron ∩ scanner| / |scanner| -- reported, not gating."""
+    report = _report(
+        cameron=frozenset({"AAAA", "BBBB", "CCCC", "DDDD"}),
+        scanner=frozenset({"AAAA", "BBBB", "XXXX"}),
+    )
+    # 2 matched of 3 picked
+    expected = Decimal(2) / Decimal(3)
+    assert report.precision == expected, (
+        f"expected 2/3, got {report.precision}"
+    )
+
+
+def test_recall_is_zero_when_cameron_is_empty() -> None:
+    """0/0 -> 0 by convention. The report still renders cleanly on empty days."""
+    report = _report(
+        cameron=frozenset(),
+        scanner=frozenset({"AAAA", "BBBB"}),
+    )
+    assert report.recall == Decimal(0)
+
+
+def test_precision_is_zero_when_scanner_is_empty() -> None:
+    """0/0 -> 0 by convention. The report still renders on a quiet scanner day."""
+    report = _report(
+        cameron=frozenset({"AAAA", "BBBB"}),
+        scanner=frozenset(),
+    )
+    assert report.precision == Decimal(0)
+
+
+def test_matched_missed_extra_set_arithmetic() -> None:
+    """matched = ∩ ; missed = cameron - scanner ; extra = scanner - cameron."""
+    report = _report(
+        cameron=frozenset({"AAAA", "BBBB", "CCCC"}),
+        scanner=frozenset({"BBBB", "CCCC", "DDDD", "EEEE"}),
+    )
+    assert report.matched == frozenset({"BBBB", "CCCC"})
+    assert report.missed == frozenset({"AAAA"})
+    assert report.extra == frozenset({"DDDD", "EEEE"})
+
+
+# ------------------------------------------------ build_daily_report (DB join)
+
+
+def test_build_daily_report_joins_journal_picks_with_ground_truth(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+    tmp_path: Path,
+) -> None:
+    """Picks for the day land in scanner; ground truth lands in cameron."""
+    day = date(2026, 5, 1)
+    # 14:30 UTC on 2026-05-01 = 10:30 ET (DST), inside the morning window.
+    inside_day = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+
+    _emit_picked(writer, ticker="AAAA", ts=inside_day)
+    _emit_picked(writer, ticker="BBBB", ts=inside_day)
+    _emit_picked(writer, ticker="EEEE", ts=inside_day)
+    # Same ticker emitted twice in the day -> still one entry in scanner-set.
+    _emit_picked(writer, ticker="AAAA", ts=inside_day)
+
+    _write_ground_truth(tmp_path, day, ["AAAA", "BBBB", "CCCC", "DDDD"])
+
+    report = build_daily_report(
+        day,
+        session_factory=session_factory,
+        ground_truth_root=tmp_path,
+    )
+
+    assert report.day == day
+    assert report.cameron == frozenset({"AAAA", "BBBB", "CCCC", "DDDD"})
+    assert report.scanner == frozenset({"AAAA", "BBBB", "EEEE"})
+    assert report.matched == frozenset({"AAAA", "BBBB"})
+    assert report.missed == frozenset({"CCCC", "DDDD"})
+    assert report.extra == frozenset({"EEEE"})
+
+
+def test_build_daily_report_filters_picks_by_ET_calendar_day(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+    tmp_path: Path,
+) -> None:
+    """Day boundary is America/New_York, not UTC.
+
+    A pick at 03:00 UTC on 2026-05-02 is 23:00 ET on 2026-05-01 -- still
+    within the 2026-05-01 ET trading day. A pick at 04:30 UTC on
+    2026-05-01 is 00:30 ET on the same date and should also be included.
+    A pick at 04:30 UTC on 2026-05-02 is 00:30 ET on 2026-05-02 and
+    must NOT appear in the 2026-05-01 report.
+    """
+    day = date(2026, 5, 1)
+
+    # 23:00 ET 2026-05-01  (= 03:00 UTC 2026-05-02 during DST)
+    late_et = datetime(2026, 5, 2, 3, 0, tzinfo=UTC)
+    # 00:30 ET 2026-05-01  (= 04:30 UTC 2026-05-01 during DST)
+    early_et = datetime(2026, 5, 1, 4, 30, tzinfo=UTC)
+    # 00:30 ET 2026-05-02  (= 04:30 UTC 2026-05-02 during DST) -- NEXT day
+    next_day = datetime(2026, 5, 2, 4, 30, tzinfo=UTC)
+
+    _emit_picked(writer, ticker="LATEET", ts=late_et)
+    _emit_picked(writer, ticker="EARLYET", ts=early_et)
+    _emit_picked(writer, ticker="NEXTDAY", ts=next_day)
+
+    _write_ground_truth(tmp_path, day, [])
+
+    report = build_daily_report(
+        day,
+        session_factory=session_factory,
+        ground_truth_root=tmp_path,
+    )
+
+    assert "LATEET" in report.scanner
+    assert "EARLYET" in report.scanner
+    assert "NEXTDAY" not in report.scanner
+
+
+def test_build_daily_report_uppercases_journal_tickers_defensively(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+    tmp_path: Path,
+) -> None:
+    """Pick.ticker is not normalized on write; report normalizes on read.
+
+    Follow-up issue tracks enforcing .upper() at the model layer; until
+    then the report defensively upper-cases so a stray lowercase journal
+    row doesn't silently miss against ground truth (which is upper-cased
+    on load by A6).
+    """
+    day = date(2026, 5, 1)
+    inside_day = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    _emit_picked(writer, ticker="aaaa", ts=inside_day)
+
+    _write_ground_truth(tmp_path, day, ["AAAA"])
+
+    report = build_daily_report(
+        day,
+        session_factory=session_factory,
+        ground_truth_root=tmp_path,
+    )
+
+    assert report.scanner == frozenset({"AAAA"})
+    assert report.matched == frozenset({"AAAA"})
+
+
+def test_build_daily_report_only_counts_picked_kind_not_other_decisions(
+    writer: JournalWriter,
+    session_factory: sessionmaker[Session],
+    tmp_path: Path,
+) -> None:
+    """stale_feed / feed_gap rows must not leak into the scanner set."""
+    day = date(2026, 5, 1)
+    inside_day = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+
+    _emit_picked(writer, ticker="REAL", ts=inside_day)
+    writer.emit(
+        ScannerDecision(
+            kind="stale_feed",
+            decision_ts=inside_day,
+            ticker=None,
+            pick=None,
+            reason="stale",
+            gap_start=None,
+            gap_end=None,
+        )
+    )
+    writer.emit(
+        ScannerDecision(
+            kind="feed_gap",
+            decision_ts=inside_day,
+            ticker=None,
+            pick=None,
+            reason="reset",
+            gap_start=inside_day,
+            gap_end=inside_day,
+        )
+    )
+
+    _write_ground_truth(tmp_path, day, ["REAL"])
+
+    report = build_daily_report(
+        day,
+        session_factory=session_factory,
+        ground_truth_root=tmp_path,
+    )
+
+    assert report.scanner == frozenset({"REAL"})
+
+
+# ---------------------------------------------------------- render_report
+
+
+def _populated_report() -> DailyReport:
+    """Hand-built non-trivial DailyReport for render-side tests."""
+    return DailyReport.from_sets(
+        day=date(2026, 5, 1),
+        cameron=frozenset({"AAAA", "BBBB", "CCCC"}),
+        scanner=frozenset({"BBBB", "CCCC", "DDDD", "EEEE"}),
+    )
+
+
+def test_render_report_is_byte_identical_across_calls() -> None:
+    """Determinism: same input -> exact same bytes, every time."""
+    report = _populated_report()
+    assert render_report(report) == render_report(report)
+
+
+def test_render_report_sorts_tickers_alphabetically_in_each_section() -> None:
+    """Tickers in matched / missed / extra appear A-Z so the bytes are stable
+    across the non-deterministic frozenset iteration order.
+    """
+    # Build a report whose three sets each contain >1 ticker so sort
+    # order is observable.
+    report = DailyReport.from_sets(
+        day=date(2026, 5, 1),
+        cameron=frozenset({"ZZZZ", "AAAA", "MMMM"}),  # missed will be all three
+        scanner=frozenset({"YYYY", "BBBB"}),  # extra will be both
+    )
+    rendered = render_report(report)
+
+    # Pull out tickers from each ## Missed (cameron - scanner) section.
+    # All three cameron tickers are missed, all two scanner tickers are extra.
+    missed_section = rendered.split("## Missed")[1].split("## ")[0]
+    assert missed_section.index("AAAA") < missed_section.index("MMMM")
+    assert missed_section.index("MMMM") < missed_section.index("ZZZZ")
+
+    extra_section = rendered.split("## Extra")[1].split("## ")[0]
+    assert extra_section.index("BBBB") < extra_section.index("YYYY")
+
+
+def test_render_report_has_definitions_section_pinning_recall_vs_precision() -> None:
+    """A reviewer should never have to re-derive the math from the body."""
+    rendered = render_report(_populated_report())
+    assert "## Definitions" in rendered
+    assert "Recall" in rendered
+    assert "Precision" in rendered
+    assert "gating" in rendered.lower()
+
+
+def test_render_report_emits_each_section_even_when_empty() -> None:
+    """Uniform shape across days. Empty sections show `_(none)_` so a
+    reviewer can't mistake a missing heading for a missing check.
+    """
+    perfect = DailyReport.from_sets(
+        day=date(2026, 5, 1),
+        cameron=frozenset({"AAAA"}),
+        scanner=frozenset({"AAAA"}),  # matched=AAAA, missed=∅, extra=∅
+    )
+    rendered = render_report(perfect)
+
+    assert "## Matched" in rendered
+    assert "## Missed" in rendered
+    assert "## Extra" in rendered
+
+    missed_section = rendered.split("## Missed")[1].split("## ")[0]
+    extra_section = rendered.split("## Extra")[1]
+    assert "_(none)_" in missed_section
+    assert "_(none)_" in extra_section
+
+
+def test_render_report_summary_section_has_counts_and_percentages() -> None:
+    """Summary must surface |cameron|, |scanner|, |matched|, recall, precision."""
+    rendered = render_report(_populated_report())  # 3 cameron, 4 scanner, 2 matched
+    assert "## Summary" in rendered
+    assert "Cameron called: 3 tickers" in rendered
+    assert "Scanner picked: 4 tickers" in rendered
+    assert "Matched: 2" in rendered
+
+
+def test_render_report_percentages_round_to_one_decimal() -> None:
+    """Recall = 8/11 -> 72.7%; precision = 8/9 -> 88.9%. Fixed precision so
+    deterministic bytes don't depend on Decimal default exponent.
+    """
+    cameron = frozenset(f"C{i:02d}" for i in range(11))
+    matched_set = {f"C{i:02d}" for i in range(8)}
+    extra_set = {f"E{i:02d}" for i in range(1)}
+    scanner = frozenset(matched_set | extra_set)  # |scanner| = 9, |matched| = 8
+
+    report = DailyReport.from_sets(
+        day=date(2026, 5, 1),
+        cameron=cameron,
+        scanner=scanner,
+    )
+    rendered = render_report(report)
+
+    assert "Recall: 8/11 = 72.7%" in rendered
+    assert "Precision: 8/9 = 88.9%" in rendered
+
+
+# ----------------------------------------------------------------------- CLI
+
+
+def test_main_writes_deterministic_report_file(
+    writer: JournalWriter,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Smoke: main() with --date + --db + roots writes reports/YYYY-MM-DD.md.
+
+    Re-running on the same inputs produces byte-identical output (the
+    file is overwritten in place; the gate is re-runnable as the journal
+    and ground truth grow).
+    """
+    day = date(2026, 5, 1)
+    inside_day = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    _emit_picked(writer, ticker="AAAA", ts=inside_day)
+    _emit_picked(writer, ticker="BBBB", ts=inside_day)
+    _write_ground_truth(tmp_path, day, ["AAAA", "CCCC"])
+
+    db_path = tmp_path / "journal.sqlite"
+    reports_dir = tmp_path / "reports"
+
+    # Use the same on-disk DB as the writer fixture: serialize the
+    # in-memory engine to a file so the CLI can open it independently.
+    # Easier: run main against the *same* file the writer wrote into.
+    # The writer fixture is in-memory by default, so for this test we
+    # write directly into a file-backed engine.
+    eng = create_journal_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(eng)
+    file_writer = JournalWriter(create_session_factory(eng))
+    _emit_picked(file_writer, ticker="AAAA", ts=inside_day)
+    _emit_picked(file_writer, ticker="BBBB", ts=inside_day)
+    eng.dispose()
+
+    rc = main(
+        [
+            "--date", day.isoformat(),
+            "--db", f"sqlite:///{db_path}",
+            "--ground-truth-root", str(tmp_path),
+            "--reports-dir", str(reports_dir),
+        ]
+    )
+    assert rc == 0
+
+    out_path = reports_dir / f"{day.isoformat()}.md"
+    assert out_path.exists(), f"expected {out_path} to be written"
+    first = out_path.read_text(encoding="utf-8")
+
+    # Stdout should surface the path written and the recall/precision summary.
+    captured = capsys.readouterr()
+    assert str(out_path) in captured.out
+    assert "Recall:" in captured.out
+
+    # Re-run: file is overwritten, bytes are identical.
+    rc2 = main(
+        [
+            "--date", day.isoformat(),
+            "--db", f"sqlite:///{db_path}",
+            "--ground-truth-root", str(tmp_path),
+            "--reports-dir", str(reports_dir),
+        ]
+    )
+    assert rc2 == 0
+    second = out_path.read_text(encoding="utf-8")
+    assert first == second


### PR DESCRIPTION
## Summary

Phase 2 — Atom A7 (#46). Closes the loop on Phase 2: joins the scanner journal (A4/A5) with the hand-curated ground truth (A6) for one trading day and writes a deterministic markdown audit artifact at `reports/YYYY-MM-DD.md`. Per Decision **D3** (#37), matching is ticker-only — time-window matching is deferred. The 70% gate itself is a manual review of A7's output.

This is the close-out atom for Phase 2. Once recall clears 70% on a historical day with a populated journal, Phase 2 is done.

## What's in here

**`src/ross_trading/journal/report.py`**

- `DailyReport` — frozen, slotted dataclass. Holds `cameron` / `scanner` / `matched` / `missed` / `extra` as `frozenset[str]`. Properties: `recall` (gating), `precision` (reported, not gating). 0/0 → 0 by convention so the report renders cleanly on quiet days at either edge.
- `build_daily_report(day, *, session_factory, ground_truth_root)` — pure function. Reads picked-set from journal, ground-truth set from A6's loader, returns a typed `DailyReport`. No I/O on disk for the writer side; rendering and persistence are separate concerns so the metric math is unit-testable on synthetic inputs.
- `render_report(report)` — deterministic markdown bytes.
- `main(argv)` — CLI entry: `--date`, `--db`, `--ground-truth-root`, `--reports-dir`. Writes the file, prints path + one-line `Recall: K/N | Precision: K/M` to stdout.

## What's NOT WatchlistEntry (and why)

The issue body (#46) literally says "joins `WatchlistEntry` rows from A4 with the ground-truth set from A6." That phrasing is a known mistake in the issue body — `WatchlistEntry` tracks open-ended watchlist membership (`added_at` / `removed_at`) and is Phase 3 graduation territory. The recall metric the 70% gate is defined against is "did the scanner pick what Cameron called out", which is the per-day picked-set.

Source of the scanner-set: distinct `Pick.ticker` for rows whose linked `ScannerDecision.kind = PICKED`, filtered to the target day. The CHECK constraint `(kind = 'picked') = (pick_id IS NOT NULL)` from #44 makes the join FK guaranteed-non-null on PICKED rows. Confirmed with @seanyofthedead before writing a line.

## Day boundary is ET, not UTC

Trading days are ET. The journal stores tz-aware UTC. The day filter converts `YYYY-MM-DD` interpreted as ET wall-clock to `[start, end)` UTC via `zoneinfo("America/New_York")`. DST handled by zoneinfo. A pick at 23:00 ET on day D lands in day D's report; a pick at 00:30 ET on day D+1 does not. The `is_market_hours` helper in `core/clock.py` already uses the same zone — this PR matches the existing convention rather than introducing a new one.

## Defensive ticker normalization (and follow-up)

`Pick.ticker` is not normalized at write time today (writer.py passes `pick.ticker` through verbatim). The ground-truth loader strip+upper-cases on load. To prevent a stray lowercase journal row from silently missing against the ground truth, the report upper-cases the journal side of the join.

A follow-up issue will be filed to enforce `.upper()` at `Pick.__init__` so future read sites don't have to remember to defensively normalize. **Out of scope for A7** — flagged on confirmation; not folded in.

## Markdown shape

Header, then `## Definitions`, `## Summary`, `## Matched`, `## Missed`, `## Extra`. Tickers within each section sorted A-Z. Percentages render as fixed one-decimal (`72.7%`). Empty sections still emit the heading with `_(none)_` underneath, so a reviewer never has to wonder whether a check was performed. No datetime stamps in the body.

## CLI defaults

- `--date YYYY-MM-DD` (required; ET)
- `--db sqlite:///journal.sqlite` (provisional; if Phase 3 ops work relocates the journal file, it's a one-line change here, and the `--help` wording does not promise this default as the convention forever)
- `--ground-truth-root PATH` (default: repo's `ground_truth/` directory; mirrors A6)
- `--reports-dir PATH` (default: `./reports`)

Re-runs overwrite `reports/YYYY-MM-DD.md` in place — the gate is re-runnable as the journal and ground truth grow. Confirmed with @seanyofthedead before wiring.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Runs on any historical day where journal + ground truth both exist | `test_main_writes_deterministic_report_file` (CLI smoke against on-disk SQLite + tmp_path ground truth) |
| Deterministic bytes for fixed inputs | `test_render_report_is_byte_identical_across_calls` + the CLI smoke re-runs and asserts identical bytes |
| Sorted A-Z within each section | `test_render_report_sorts_tickers_alphabetically_in_each_section` |
| `Decimal`-formatted, fixed-precision percentages | `test_render_report_percentages_round_to_one_decimal` (8/11 → 72.7%; 8/9 → 88.9%) |
| No datetime stamps in body | the only date in `render_report` output is `report.day` in the title |
| Metric math unit-tested with synthetic inputs (NOT integration vs real data) | 5 metric tests against `DailyReport.from_sets` directly |
| Definitions section pins recall vs precision | `test_render_report_has_definitions_section_pinning_recall_vs_precision` |
| `mypy --strict` clean | full repo: 80 source files, 0 issues |
| `ruff check` clean | All checks passed! |
| Full suite stays green | 273/273 (was 257 + 16 new) |

## Tests

16 new tests, all green; 273/273 in the full suite (was 247 before A6, 257 before A7).

- Metric math (5): recall/precision happy paths, both 0/0 corner cases, set arithmetic for matched/missed/extra.
- DB integration (4): join against synthetic in-memory journal + tmp_path ground truth, ET day boundary, defensive upper-casing on `Pick.ticker`, and that `stale_feed` / `feed_gap` rows do NOT leak into the scanner set.
- Render (5): byte-identical determinism, A-Z sorting, Definitions present, uniform section emission with `_(none)_` on empty, summary counts + one-decimal percentages.
- CLI smoke (1): `main()` writes `reports/YYYY-MM-DD.md`, returns 0, prints path + summary to stdout, re-run produces identical bytes.

## What's NOT in this PR

Per the issue's "out of scope" + the confirmation:

- Phase 3 watchlist graduation logic.
- Time-window matching (D3 deferred).
- Multi-day rollups, weekly/monthly summaries, dashboards.
- Persisting recall back to the journal.
- The actual evaluation of whether the gate clears 70% — that's a manual review step on A7's output.
- Enforcing `.upper()` at `Pick.__init__` — separate follow-up issue.

## Verification

- `python -m mypy --strict src tests` → `Success: no issues found in 80 source files`
- `python -m ruff check` → `All checks passed!`
- `python -m pytest` → `273 passed in 38.56s`

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)