### PR TITLE
docs(readme): document drift CI gate and add status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Currently in Phase 2: scanner + journaling, no live trading.
 ## Status
 
 [![CI](https://github.com/seanyofthedead/Ross-trading/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/seanyofthedead/Ross-trading/actions/workflows/ci.yml)
+[![Drift CI](https://github.com/seanyofthedead/Ross-trading/actions/workflows/drift-ci.yml/badge.svg?branch=main)](https://github.com/seanyofthedead/Ross-trading/actions/workflows/drift-ci.yml)
+
+Pull requests are gated by [Drift CI](docs/drift-control.md): baseline checks (ruff, mypy, pytest, alembic) plus a Claude-powered drift audit that compares the diff against `docs/architecture.md`, `docs/ground_truth.md`, and the active `plans/`. See `docs/drift-control.md` for severity rules and the waiver process.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

- Adds a Drift CI status badge.
- One-paragraph pointer to `docs/drift-control.md` so contributors discover the gate without digging.

This is also the **first end-to-end smoke test** of the drift CI pipeline after #75 landed: this PR does not modify `.github/workflows/drift-ci.yml` or `.github/prompts/drift-pr-audit.md`, so the Claude action will run against this diff instead of self-skipping. Expected outcome: drift report comes back empty (this is a docs-only change, no architecture impact).

## Test plan

- [x] Local: README renders correctly
- [ ] Drift CI green (Baseline + Drift scan)
- [ ] Bot posts a `<!-- drift-ci:report -->` comment with no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)