### PR TITLE
feat(journal): enforce ticker .upper() at model layer (#58)

### DIFF
--- a/src/ross_trading/journal/models.py
+++ b/src/ross_trading/journal/models.py
@@ -35,7 +35,7 @@ from sqlalchemy import (
     String,
     text,
 )
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, validates
 
 from ross_trading.journal.types import DecimalText, TzAwareUTC
 
@@ -99,6 +99,13 @@ class Pick(Base):
 
     __table_args__ = (Index("ix_picks_ticker_ts", "ticker", "ts"),)
 
+    @validates("ticker")
+    def _normalize_ticker(self, _key: str, value: str) -> str:
+        # #58: enforce upper-case at the storage boundary so read sites
+        # joining against ground truth (already upper-cased on load) cannot
+        # silently miss a stray lowercase upstream.
+        return value.strip().upper()
+
 
 class WatchlistEntry(Base):
     """Open-ended watchlist membership for a :class:`Pick`.
@@ -129,6 +136,10 @@ class WatchlistEntry(Base):
             postgresql_where=text("removed_at IS NULL"),
         ),
     )
+
+    @validates("ticker")
+    def _normalize_ticker(self, _key: str, value: str) -> str:
+        return value.strip().upper()
 
 
 class ScannerDecision(Base):
@@ -197,3 +208,10 @@ class ScannerDecision(Base):
             name="ck_scanner_decisions_ticker_required",
         ),
     )
+
+    @validates("ticker")
+    def _normalize_ticker(self, _key: str, value: str | None) -> str | None:
+        # ``stale_feed`` and ``feed_gap`` decisions have ticker=None.
+        if value is None:
+            return None
+        return value.strip().upper()

--- a/src/ross_trading/journal/report.py
+++ b/src/ross_trading/journal/report.py
@@ -17,11 +17,11 @@ The day boundary is America/New_York (matches the scanner's
 stored in tz-aware UTC are filtered against ``[YYYY-MM-DD 00:00 ET,
 +1d 00:00 ET)`` translated to UTC. DST is handled by zoneinfo.
 
-Pick.ticker is not normalized at the model layer today (a follow-up
-issue tracks enforcing ``.upper()`` at ``Pick.__init__``); this module
-defensively upper-cases the journal side of the join so a stray
-lowercase row doesn't silently miss against the ground truth, which A6
-already upper-cases on load.
+``Pick.ticker`` is enforced upper-case at the model layer (``Pick``'s
+``@validates("ticker")``, #58). This module keeps a defensive
+``.upper()`` on the journal side of the join as belt-and-braces; the
+model-layer normalization is the primary line of defence and the
+ground-truth side already upper-cases on load.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_journal_models.py
+++ b/tests/unit/test_journal_models.py
@@ -297,3 +297,90 @@ def test_decision_kind_includes_reserved_rejected() -> None:
         "feed_gap",
         "rejected",
     }
+
+
+# ----- #58: enforce ticker normalization at the model layer ------------------
+#
+# Read sites that join journal rows against ground truth (already
+# upper-cased on load) rely on journal tickers being upper. The defensive
+# ``.upper()`` in ``build_daily_report`` keeps recall correct today but
+# pushes the burden onto every read site. These tests pin storage-layer
+# normalization so any future read site can trust the contract.
+
+
+def test_pick_normalizes_lowercase_ticker_to_upper(session: Session) -> None:
+    pick = _make_pick(ticker="abcd")
+    assert pick.ticker == "ABCD"  # normalized at __init__, before flush
+
+    session.add(pick)
+    session.commit()
+    fetched = session.get(Pick, pick.id)
+    assert fetched is not None
+    assert fetched.ticker == "ABCD"
+
+
+def test_pick_strips_whitespace_from_ticker() -> None:
+    pick = _make_pick(ticker="  abcd\t")
+    assert pick.ticker == "ABCD"
+
+
+def test_pick_normalizes_ticker_on_assignment() -> None:
+    pick = _make_pick(ticker="ABCD")
+    pick.ticker = "wxyz"
+    assert pick.ticker == "WXYZ"
+
+
+def test_watchlist_entry_normalizes_ticker(session: Session) -> None:
+    pick = _make_pick()
+    session.add(pick)
+    session.flush()
+
+    entry = WatchlistEntry(
+        ticker="abcd",
+        pick_id=pick.id,
+        added_at=datetime(2026, 5, 2, 14, 31, tzinfo=UTC),
+    )
+    assert entry.ticker == "ABCD"
+
+    session.add(entry)
+    session.commit()
+    fetched = session.get(WatchlistEntry, entry.id)
+    assert fetched is not None
+    assert fetched.ticker == "ABCD"
+
+
+def test_decision_normalizes_ticker_when_present(session: Session) -> None:
+    pick = _make_pick()
+    session.add(pick)
+    session.flush()
+
+    decision = ScannerDecision(
+        kind=DecisionKind.PICKED,
+        decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ticker="abcd",
+        pick_id=pick.id,
+    )
+    assert decision.ticker == "ABCD"
+
+    session.add(decision)
+    session.commit()
+    fetched = session.get(ScannerDecision, decision.id)
+    assert fetched is not None
+    assert fetched.ticker == "ABCD"
+
+
+def test_decision_passes_none_ticker_through(session: Session) -> None:
+    """``stale_feed`` and ``feed_gap`` decisions have ``ticker=None``."""
+    decision = ScannerDecision(
+        kind=DecisionKind.STALE_FEED,
+        decision_ts=datetime(2026, 5, 2, 14, 30, tzinfo=UTC),
+        ticker=None,
+        reason="stale",
+    )
+    assert decision.ticker is None
+
+    session.add(decision)
+    session.commit()
+    fetched = session.get(ScannerDecision, decision.id)
+    assert fetched is not None
+    assert fetched.ticker is None


### PR DESCRIPTION
## Summary

Closes #58. Adds `@validates("ticker")` to `Pick`, `WatchlistEntry`, and `ScannerDecision` so the storage boundary strips and upper-cases ticker values, regardless of upstream call-site discipline.

## Why

Today every read site that joins against ground truth (already upper-cased on load) has to remember to defensively `.upper()` — `build_daily_report` does this at `journal/report.py:145`. A single drift in any upstream call site would silently land lowercase rows that wouldn't match against ground truth, corrupting the Phase 2 recall-gate measurement.

Pinning normalization at the model layer eliminates that class of drift before #70's recall computation runs.

## What changed

- `src/ross_trading/journal/models.py` — `@validates("ticker")` on all three model classes; the `ScannerDecision` validator passes `None` through (`stale_feed` and `feed_gap` rows have no ticker).
- `src/ross_trading/journal/report.py` — module docstring updated to reflect that the defensive `.upper()` is now belt-and-braces, not the primary line of defence.
- `tests/unit/test_journal_models.py` — five new tests covering: lowercase normalization (with round-trip), whitespace stripping, normalization on assignment after construction, `WatchlistEntry`/`ScannerDecision` parity, and `None` passthrough on `ScannerDecision`.

## Test evidence

```
ruff check src tests             -> All checks passed!
mypy --strict src tests          -> Success: no issues found in 77 source files
pytest                           -> 321 passed in 62.6s
pytest tests/unit/test_journal_models.py -> 26 passed
```

RED→GREEN: confirmed the new tests failed against the unmodified `models.py` before adding the validators (5 expected failures, 0 errors).

## Acceptance checklist (from #58)

- [x] `Pick.ticker` is upper-case after `Pick(ticker="abcd", ...)` (round-trip test).
- [x] `WatchlistEntry.ticker` and `ScannerDecision.ticker` get the same treatment.
- [x] `mypy --strict`, `ruff check`, full pytest stay green.
- [x] No churn to `build_daily_report`'s defensive `.upper()`; only the surrounding module docstring updated.

## Risk / rollback

- No migration; no backfill (per #58 out-of-scope: journal is short-lived dev data).
- Storage-layer tightening, not a behaviour change for any caller that was already producing upper-case input — which is what every existing call site does today (verified: `scanner/filters.py`, `data/providers/replay.py`, `data/types.py::Headline.dedup_key`).
- Rollback = revert this commit; defensive `.upper()` continues to mask drift.