### PR TITLE
feat(scanner): daily-chart strength filter (#72)

### DIFF
--- a/src/ross_trading/scanner/strength.py
+++ b/src/ross_trading/scanner/strength.py
@@ -1,0 +1,91 @@
+"""Daily-chart strength filter (architecture §3.3).
+
+Phase 3 — Atom A1 (#72, tracks under #4). Pure-function consumer of
+the ``daily_emas`` cache populated by
+``data.historical.precompute_daily_emas``.
+
+Scoring (per Cameron's Gap and Go, TA Series p.4):
+
+* ``score = (close > EMA20) + (close > EMA50) + (close > EMA200)``
+  + breakout flag + turnaround flag.
+* Range today: 0..3 (the breakout / turnaround inputs are not yet
+  wired; they are emitted as ``None`` until follow-up atom #73 lands
+  and the score range expands to 0..5).
+* Threshold semantics live with the consumer (not here): score ≥ 2 →
+  *keep*, score 0-1 → *demote*.
+
+Cache-as-source-of-truth: a missing ``daily_emas`` row for any of the
+three periods returns ``score=None`` and the corresponding
+``above_emaXX=None`` (matching ``filters.float_le`` "absence of
+evidence is not promotion" semantics). Recomputing on the fly is the
+job of ``precompute_daily_emas``.
+
+Strict greater-than: ``close == EMA`` returns ``False`` for that EMA,
+mirroring the architecture-doc pseudocode exactly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import date
+    from decimal import Decimal
+
+    from ross_trading.data.cache import HistoricalCache
+
+
+@dataclass(frozen=True, slots=True)
+class DailyStrengthScore:
+    """Strength-filter result for a single (symbol, day).
+
+    A field set to ``None`` means "no evidence" (cache miss or flag
+    not yet wired). Consumers must treat ``None`` as a demotion
+    signal, not as a permissive default.
+    """
+
+    score: int | None
+    above_ema20: bool | None
+    above_ema50: bool | None
+    above_ema200: bool | None
+    breakout: bool | None
+    turnaround: bool | None
+
+
+_PERIODS = (20, 50, 200)
+
+
+def score_daily_strength(
+    symbol: str,
+    as_of: date,
+    daily_close: Decimal,
+    cache: HistoricalCache,
+) -> DailyStrengthScore:
+    """Score *symbol* against its EMA20 / EMA50 / EMA200 for *as_of*.
+
+    Returns a :class:`DailyStrengthScore`. ``score`` is the sum of
+    ``daily_close > EMA{20,50,200}`` when all three rows exist in the
+    cache; if any row is missing, ``score`` is ``None`` and the
+    corresponding ``above_emaXX`` flag is ``None``. ``breakout`` and
+    ``turnaround`` are always ``None`` until the follow-up atom (#73)
+    wires their inputs.
+    """
+    flags: dict[int, bool | None] = {
+        period: None if (ema := cache.ema(symbol, as_of, period)) is None
+        else daily_close > ema
+        for period in _PERIODS
+    }
+    score = (
+        sum(int(flag) for flag in flags.values() if flag is not None)
+        if all(flag is not None for flag in flags.values())
+        else None
+    )
+    return DailyStrengthScore(
+        score=score,
+        above_ema20=flags[20],
+        above_ema50=flags[50],
+        above_ema200=flags[200],
+        breakout=None,
+        turnaround=None,
+    )

--- a/tests/unit/test_scanner_strength.py
+++ b/tests/unit/test_scanner_strength.py
@@ -1,0 +1,176 @@
+"""Phase 3 — A1 daily-chart strength filter (issue #72)."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from ross_trading.data.cache import HistoricalCache
+from ross_trading.scanner.strength import DailyStrengthScore, score_daily_strength
+
+AS_OF = date(2026, 5, 8)
+
+
+def _populated_cache(
+    *,
+    ema20: str | None = "5.00",
+    ema50: str | None = "5.00",
+    ema200: str | None = "5.00",
+    symbol: str = "AVTX",
+) -> HistoricalCache:
+    cache = HistoricalCache(":memory:")
+    if ema20 is not None:
+        cache.record_ema(symbol, AS_OF, 20, Decimal(ema20))
+    if ema50 is not None:
+        cache.record_ema(symbol, AS_OF, 50, Decimal(ema50))
+    if ema200 is not None:
+        cache.record_ema(symbol, AS_OF, 200, Decimal(ema200))
+    return cache
+
+
+# ---------------------------------------------------------------- DailyStrengthScore
+
+
+def test_score_dataclass_is_frozen_with_slots() -> None:
+    assert is_dataclass(DailyStrengthScore)
+    field_names = {f.name for f in fields(DailyStrengthScore)}
+    assert field_names == {
+        "score",
+        "above_ema20",
+        "above_ema50",
+        "above_ema200",
+        "breakout",
+        "turnaround",
+    }
+    instance = DailyStrengthScore(
+        score=3,
+        above_ema20=True,
+        above_ema50=True,
+        above_ema200=True,
+        breakout=None,
+        turnaround=None,
+    )
+    # `frozen=True` blocks mutation of declared fields.
+    from dataclasses import FrozenInstanceError
+
+    with pytest.raises(FrozenInstanceError):
+        instance.score = 0  # type: ignore[misc]
+    # `slots=True` removes ``__dict__``.
+    assert not hasattr(instance, "__dict__")
+
+
+# ---------------------------------------------------------------- score_daily_strength
+
+
+@pytest.mark.parametrize(
+    ("close", "ema20", "ema50", "ema200", "expected_score", "expected_flags"),
+    [
+        # All three above → score 3.
+        ("5.50", "5.00", "5.00", "5.00", 3, (True, True, True)),
+        # All three below → score 0.
+        ("4.50", "5.00", "5.00", "5.00", 0, (False, False, False)),
+        # Mixed: above 20 + 200, below 50 → score 2.
+        ("5.50", "5.00", "6.00", "5.00", 2, (True, False, True)),
+        # Mixed: above 20 only → score 1.
+        ("5.50", "5.00", "6.00", "6.00", 1, (True, False, False)),
+    ],
+)
+def test_score_combines_three_emas(
+    close: str,
+    ema20: str,
+    ema50: str,
+    ema200: str,
+    expected_score: int,
+    expected_flags: tuple[bool, bool, bool],
+) -> None:
+    cache = _populated_cache(ema20=ema20, ema50=ema50, ema200=ema200)
+
+    result = score_daily_strength("AVTX", AS_OF, Decimal(close), cache)
+
+    assert result.score == expected_score
+    assert (result.above_ema20, result.above_ema50, result.above_ema200) == expected_flags
+    # Breakout and turnaround stay None until follow-up atom #73 lands.
+    assert result.breakout is None
+    assert result.turnaround is None
+
+
+@pytest.mark.parametrize("ema_value", ["5.00", "5.0000000000", "5"])
+def test_close_equal_to_ema_is_strict_greater_than(ema_value: str) -> None:
+    """`close == EMA` → False (architecture §3.3 uses `>`, not `>=`)."""
+    cache = _populated_cache(ema20=ema_value, ema50=ema_value, ema200=ema_value)
+
+    result = score_daily_strength("AVTX", AS_OF, Decimal("5.00"), cache)
+
+    assert result.above_ema20 is False
+    assert result.above_ema50 is False
+    assert result.above_ema200 is False
+    assert result.score == 0
+
+
+def test_close_one_cent_above_ema_passes() -> None:
+    cache = _populated_cache(ema20="5.00", ema50="5.00", ema200="5.00")
+
+    result = score_daily_strength("AVTX", AS_OF, Decimal("5.01"), cache)
+
+    assert result.score == 3
+    assert result.above_ema20 is True
+    assert result.above_ema50 is True
+    assert result.above_ema200 is True
+
+
+def test_close_one_cent_below_ema_fails() -> None:
+    cache = _populated_cache(ema20="5.00", ema50="5.00", ema200="5.00")
+
+    result = score_daily_strength("AVTX", AS_OF, Decimal("4.99"), cache)
+
+    assert result.score == 0
+    assert result.above_ema20 is False
+    assert result.above_ema50 is False
+    assert result.above_ema200 is False
+
+
+def test_missing_single_ema_yields_score_none_with_partial_flags() -> None:
+    cache = _populated_cache(ema20="5.00", ema50="5.00", ema200=None)
+
+    result = score_daily_strength("AVTX", AS_OF, Decimal("5.50"), cache)
+
+    assert result.score is None
+    assert result.above_ema20 is True
+    assert result.above_ema50 is True
+    assert result.above_ema200 is None
+
+
+def test_all_emas_missing_yields_all_none() -> None:
+    cache = _populated_cache(ema20=None, ema50=None, ema200=None)
+
+    result = score_daily_strength("AVTX", AS_OF, Decimal("5.50"), cache)
+
+    assert result.score is None
+    assert result.above_ema20 is None
+    assert result.above_ema50 is None
+    assert result.above_ema200 is None
+    assert result.breakout is None
+    assert result.turnaround is None
+
+
+def test_lookup_is_case_insensitive_via_cache_normalization() -> None:
+    """`HistoricalCache.ema` upper-cases the symbol; scorer must round-trip cleanly."""
+    cache = _populated_cache(ema20="5.00", ema50="5.00", ema200="5.00", symbol="avtx")
+
+    result = score_daily_strength("avtx", AS_OF, Decimal("5.50"), cache)
+
+    assert result.score == 3
+
+
+def test_other_symbol_is_isolated() -> None:
+    cache = _populated_cache(ema20="5.00", ema50="5.00", ema200="5.00", symbol="AVTX")
+
+    result = score_daily_strength("ZZZZ", AS_OF, Decimal("5.50"), cache)
+
+    assert result.score is None
+    assert result.above_ema20 is None
+    assert result.above_ema50 is None
+    assert result.above_ema200 is None


### PR DESCRIPTION
## Summary

Phase 3 atom **A1** (issue #72, tracks under #4): pure-function consumer of the `daily_emas` cache that scores each ticker against EMA20 / EMA50 / EMA200 per `docs/architecture.md` §3.3.

- New `src/ross_trading/scanner/strength.py` with `DailyStrengthScore` (frozen-slots) and `score_daily_strength(symbol, as_of, daily_close, cache)`.
- New `tests/unit/test_scanner_strength.py` covering boundary cases, cache misses, and case-insensitive symbol lookup.
- Follows the plan in `plans/phase-3-issue-72-daily-strength.md`.

## Issue addressed

Closes #72.

## What changed

- **Strict greater-than** comparison (`close > EMA`) matches the architecture pseudocode exactly. `close == EMA` returns `False` for that EMA.
- **Cache-as-source-of-truth.** A missing `daily_emas` row for any of the three periods returns `score=None` and the corresponding `above_emaXX=None`, mirroring `filters.float_le` "absence of evidence is not promotion" semantics. No on-the-fly recomputation here — that's the job of `data.historical.precompute_daily_emas`.
- **Deferred flags.** `breakout` and `turnaround` are emitted as `None` until follow-up atom #73 wires their inputs. Score range stays at 0..3 in this atom; consumer-side keep/demote threshold (≥2) is unchanged.
- No modifications to `data/cache.py`, `data/historical.py`, or any scanner orchestrator. Scanner-side wiring is a separate atom.

## Test evidence

```
$ python -m pytest tests/unit/test_scanner_strength.py -v
14 passed

$ python -m pytest -m "not integration"
299 passed, 36 deselected

$ python -m ruff check src tests
All checks passed!

$ python -m mypy src tests
Success: no issues found in 79 source files
```

Test coverage:
- `score = sum(above_emaXX)` over 4 close/EMA combinations (3, 0, 2, 1).
- `close == EMA` strict-`>` boundary (3 numeric forms: `5.00`, `5.0000000000`, `5`).
- ±1¢ around EMA.
- Single missing EMA → `score=None` with partial flags observable.
- All EMAs missing → all flags `None`.
- Case-insensitive symbol lookup via `HistoricalCache` normalization.
- Symbol isolation (other-ticker rows do not leak).
- `DailyStrengthScore` is frozen + slotted (no `__dict__`).

## Risk / rollback notes

- Pure additive change — two new files, zero modifications to existing modules. Reverting the PR is safe and isolated.
- No new dependencies.
- No I/O concurrency added; the function is sync against the local SQLite cache.

## Follow-ups

- #73 — breakout / turnaround flags (deferred per the plan).
- Scanner-side wiring (separate atom, not yet filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)