### PR TITLE
test(scanner): cover stale_feed replay-driver decisions (#74)

### DIFF
--- a/src/ross_trading/scanner/replay.py
+++ b/src/ross_trading/scanner/replay.py
@@ -33,6 +33,15 @@ of the two options that's compatible with how the loop actually writes.
 Synthetic-tick fallback (the issue's "no recordings" risk) is reserved
 for a follow-up atom. Today, if ``recordings_dir`` has no events for
 ``day`` the assembler returns empty bounds and the journal stays clean.
+
+FEED_GAP decisions don't surface from replay. A live loop reifies them
+via ``ReconnectingProvider(upstream, on_gap=loop.on_feed_gap)`` (see
+``ScannerLoop.on_feed_gap``); the bare :class:`ReplayProvider` used here
+has no ``on_gap`` callback because a deterministic recording has no
+reconnect events to model. STALE_FEED still surfaces naturally -- the
+loop fires it whenever ``anchor_ts - latest_quote_ts`` exceeds
+``staleness_threshold_s``, which happens during the
+``_REPLAY_TAIL_PAD`` window after the recording's last quote.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_scanner_replay.py
+++ b/tests/integration/test_scanner_replay.py
@@ -224,6 +224,56 @@ async def test_replay_day_propagates_loop_exception(tmp_path: Path) -> None:
         engine.dispose()
 
 
+async def test_replay_day_emits_stale_feed_when_quotes_age_past_threshold(
+    tmp_path: Path,
+) -> None:
+    """#74 AC: replay must surface ``stale_feed`` decisions, not just picks/rejects.
+
+    The recording has exactly one quote at ``WINDOW_OPEN``. The driver pads
+    the run by ``_REPLAY_TAIL_PAD`` (10s) past the last recorded event, so
+    the loop ticks at offsets +0/+2/+4/+6/+8 seconds from ``WINDOW_OPEN``
+    on the default ``tick_interval_s=2.0``. With the default
+    ``staleness_threshold_s=5.0``, the +6s and +8s ticks observe a quote
+    that's older than the threshold and emit ``stale_feed`` -- the same
+    decision the live loop would emit when its feed goes silent.
+
+    ``feed_gap`` is intentionally not exercised here: it only surfaces in
+    production when a ``ReconnectingProvider`` fires its ``on_gap``
+    callback, which replay's bare ``ReplayProvider`` doesn't have. The
+    replay driver carries no FeedGap source of its own -- a deterministic
+    recording has no reconnect events to reify.
+    """
+    recordings, universe_dir = _setup_fixture(tmp_path, "AVTX")
+    await _record_passing_day(recordings, "AVTX")
+
+    engine = create_journal_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    try:
+        await replay_day(
+            day=DAY,
+            recordings_dir=recordings,
+            universe_dir=universe_dir,
+            journal_engine=engine,
+        )
+        session_factory = create_session_factory(engine)
+        with session_factory() as session:
+            stale_rows = session.execute(
+                select(ScannerDecisionRow).where(
+                    ScannerDecisionRow.kind == DecisionKind.STALE_FEED,
+                ),
+            ).scalars().all()
+    finally:
+        engine.dispose()
+
+    assert len(stale_rows) >= 1
+    assert all(row.ticker is None for row in stale_rows)
+    assert all(row.rejection_reason is None for row in stale_rows)
+    assert all(
+        row.reason is not None and "stale" in row.reason
+        for row in stale_rows
+    )
+
+
 async def test_replay_day_writes_rejected_decisions_to_journal(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Closes the last unverified acceptance criterion in #74 (\"emits the same decision stream a live loop would: PICKED, REJECTED, STALE_FEED, FEED_GAP\") by adding an integration test that pins the `stale_feed` path in the replay driver.
- Documents on `scanner/replay.py` why `feed_gap` doesn't surface from replay (it requires a `ReconnectingProvider.on_gap` callback that the bare `ReplayProvider` doesn't have).

## Why

After PRs #79 (skeleton) and #83 (rejected coverage), the replay driver still only had end-to-end tests for `PICKED` and `REJECTED`. The loop's `stale_feed` branch was firing in replay too -- the recording's last quote ages past `staleness_threshold_s` during the `_REPLAY_TAIL_PAD` tail -- but nothing pinned that behavior. Future changes to the staleness check or the tail-pad sizing could silently regress the AC.

## What changed

- `tests/integration/test_scanner_replay.py` — new `test_replay_day_emits_stale_feed_when_quotes_age_past_threshold`. Reuses the existing `_record_passing_day` fixture (single quote at `WINDOW_OPEN`); default `tick_interval_s=2.0` + `staleness_threshold_s=5.0` + `_REPLAY_TAIL_PAD=10s` puts ticks at offsets +0/+2/+4/+6/+8s, so +6s and +8s exceed the threshold and emit `stale_feed`. Asserts ≥1 row with `kind=STALE_FEED`, `ticker=None`, `rejection_reason=None`, and a reason containing \"stale\".
- `src/ross_trading/scanner/replay.py` — adds a paragraph to the module docstring explaining that `feed_gap` doesn't surface in replay (no `on_gap` source) and that `stale_feed` does (timing-driven).

## Test evidence

- New test passes locally (12.86s).
- `pytest` full suite: **352 passed in 225s**.
- `ruff check src tests`: All checks passed.
- `mypy --strict`: Success: no issues found in 79 source files.
- Verified the assertion is meaningful: temporarily replaced the loop's threshold check with `> 999999.0`; the new test failed with `assert 0 >= 1`; reverted the loop file before committing.

## Risk / rollback

- Pure-additive change (1 test + a docstring paragraph). No behavior change.
- Rollback = revert this single commit.

## Issue tracking

Addresses the final AC bullet from #74. After merge, every kind in the live-loop decision stream that the replay driver can emit is covered: `PICKED` (test_replay_day_writes_picks_to_journal), `REJECTED` (test_replay_day_writes_rejected_decisions_to_journal), `STALE_FEED` (this PR). `FEED_GAP` is documented as out-of-scope for the deterministic-recording driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)