### PR TITLE
feat(data): live capture composition wires recorder behind reconnect (#87)

### DIFF
--- a/src/ross_trading/data/capture.py
+++ b/src/ross_trading/data/capture.py
@@ -1,0 +1,204 @@
+"""Live capture composition (#87).
+
+Vendor-agnostic glue that runs a live :class:`MarketDataProvider`
+behind :class:`ReconnectingProvider` and pipes every event into a
+:class:`FeedRecorder`. The composition closes the production-side half
+of the FEED_GAP loop that PR #86 opened on the replay side: the
+recorder's ``record_feed_gap`` is wired as the reconnect ``on_gap``
+callback, so reconnect-induced gap windows persist to disk alongside
+the rest of the streams.
+
+Vendor-neutral: the composition only depends on the existing
+``MarketDataProvider`` / ``NewsProvider`` / ``FloatReferenceProvider``
+Protocols, so it can land and be tested with fakes today without
+waiting on the #11 vendor decision.
+
+Out of scope: live trading composition (recorder + scanner + journal in
+one process), CLI daemon wrapper, recording rotation/archival policy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from ross_trading.core.clock import Clock, RealClock
+from ross_trading.core.errors import FeedError
+from ross_trading.data.market_feed import Timeframe
+from ross_trading.data.reconnect import DEFAULT_MAX_BACKOFF, ReconnectingProvider
+from ross_trading.data.recorder import FeedRecorder
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from datetime import date
+    from pathlib import Path
+
+    from ross_trading.data.float_reference import FloatReferenceProvider
+    from ross_trading.data.market_feed import MarketDataProvider
+    from ross_trading.data.news_feed import NewsProvider
+
+
+_DEFAULT_TIMEFRAMES: tuple[Timeframe, ...] = (Timeframe.M1, Timeframe.D1)
+
+
+async def capture_session(
+    *,
+    upstream_market_data: MarketDataProvider,
+    upstream_news: NewsProvider | None,
+    upstream_float: FloatReferenceProvider | None,
+    universe: Iterable[str],
+    output_dir: Path,
+    timeframes: Iterable[Timeframe] = _DEFAULT_TIMEFRAMES,
+    as_of: date | None = None,
+    clock: Clock | None = None,
+    max_backoff: float = DEFAULT_MAX_BACKOFF,
+) -> None:
+    """Run a recording session for ``universe`` until every upstream stream ends.
+
+    The market provider is wrapped in :class:`ReconnectingProvider` with
+    ``on_gap=recorder.record_feed_gap``, so disconnect/reconnect cycles
+    persist a ``FeedGap`` row to disk alongside the live event streams.
+    Backfilled bars produced by the reconnect wrapper after recovery are
+    written through the same ``record_bar`` path, leaving the recording
+    internally consistent: the gap window contains both the marker and
+    the recovered bars.
+
+    Termination: the composition runs until every ``subscribe_*`` stream
+    is exhausted. Tests therefore drive it with finite-fake providers;
+    production deployments cancel the surrounding task to stop.
+
+    Errors: any exception other than the reconnect-handled
+    :class:`FeedDisconnected` propagates out so the caller can fail loudly
+    instead of silently losing the recording session. The recorder is
+    flushed and closed in all paths via the async-context exit.
+    """
+    symbols = tuple(s.upper() for s in universe)
+    timeframe_list = tuple(timeframes)
+    _validate_timeframes(upstream_market_data, timeframe_list)
+
+    real_clock: Clock = clock if clock is not None else RealClock()
+
+    async with FeedRecorder(output_dir, clock=real_clock) as recorder:
+        market = ReconnectingProvider(
+            upstream_market_data,
+            on_gap=recorder.record_feed_gap,
+            max_backoff=max_backoff,
+            clock=real_clock,
+        )
+        await market.connect()
+        if upstream_news is not None:
+            await upstream_news.connect()
+        try:
+            await _capture_floats(upstream_float, recorder, symbols, as_of, real_clock)
+            tasks: list[asyncio.Task[None]] = [
+                asyncio.create_task(_capture_quotes(market, recorder, symbols)),
+                asyncio.create_task(_capture_tape(market, recorder, symbols)),
+            ]
+            for tf in timeframe_list:
+                tasks.append(
+                    asyncio.create_task(_capture_bars(market, recorder, symbols, tf))
+                )
+            if upstream_news is not None:
+                tasks.append(
+                    asyncio.create_task(
+                        _capture_headlines(upstream_news, recorder, symbols)
+                    )
+                )
+            try:
+                await asyncio.gather(*tasks)
+            except BaseException:
+                # gather() doesn't auto-cancel siblings when one task fails.
+                # We cancel the rest and drain them so the original error
+                # surfaces unwrapped (TaskGroup would wrap it in
+                # ExceptionGroup) and no task is left orphaned.
+                for t in tasks:
+                    if not t.done():
+                        t.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise
+        finally:
+            await market.disconnect()
+            if upstream_news is not None:
+                await upstream_news.disconnect()
+
+
+def _validate_timeframes(
+    provider: MarketDataProvider,
+    timeframes: tuple[Timeframe, ...],
+) -> None:
+    supported = provider.supported_timeframes
+    missing = [tf for tf in timeframes if tf not in supported]
+    if missing:
+        msg = (
+            f"requested timeframes not supported by upstream: {missing!r} "
+            f"(provider supports {sorted(s.value for s in supported)!r})"
+        )
+        raise ValueError(msg)
+
+
+async def _capture_quotes(
+    market: ReconnectingProvider,
+    recorder: FeedRecorder,
+    symbols: tuple[str, ...],
+) -> None:
+    async for quote in market.subscribe_quotes(symbols):
+        recorder.record_quote(quote)
+
+
+async def _capture_tape(
+    market: ReconnectingProvider,
+    recorder: FeedRecorder,
+    symbols: tuple[str, ...],
+) -> None:
+    async for trade in market.subscribe_tape(symbols):
+        recorder.record_tape(trade)
+
+
+async def _capture_bars(
+    market: ReconnectingProvider,
+    recorder: FeedRecorder,
+    symbols: tuple[str, ...],
+    timeframe: Timeframe,
+) -> None:
+    async for bar in market.subscribe_bars(symbols, timeframe):
+        recorder.record_bar(bar)
+
+
+async def _capture_headlines(
+    news: NewsProvider,
+    recorder: FeedRecorder,
+    symbols: tuple[str, ...],
+) -> None:
+    async for headline in news.subscribe_headlines(symbols):
+        recorder.record_headline(headline)
+
+
+async def _capture_floats(
+    float_provider: FloatReferenceProvider | None,
+    recorder: FeedRecorder,
+    symbols: tuple[str, ...],
+    as_of: date | None,
+    clock: Clock,
+) -> None:
+    """Snapshot the daily float reference for each ticker once at session start.
+
+    Float is a daily, slow-moving reference -- one fetch per ticker per
+    session is sufficient and matches the cadence the cached provider
+    already enforces. Per-ticker :class:`FeedError` (missing record, vendor
+    rate-limit on that ticker) is swallowed so a single bad lookup doesn't
+    kill the rest of the recording; non-FeedError exceptions (e.g.
+    programming errors or transport failures the provider doesn't wrap)
+    still propagate.
+    """
+    if float_provider is None:
+        return
+    snapshot_day = as_of if as_of is not None else clock.now().date()
+    for ticker in symbols:
+        try:
+            record = await float_provider.get_float(ticker, snapshot_day)
+        except FeedError:
+            # Single-ticker vendor gap; recording the rest of the session
+            # is more valuable than failing the whole capture for one
+            # missing record.
+            continue
+        recorder.record_float(record)

--- a/src/ross_trading/data/capture.py
+++ b/src/ross_trading/data/capture.py
@@ -86,9 +86,17 @@ async def capture_session(
             clock=real_clock,
         )
         await market.connect()
-        if upstream_news is not None:
-            await upstream_news.connect()
+        # ``news_connected`` guards the symmetric cleanup case: if
+        # ``upstream_news.connect()`` raises, we must still disconnect
+        # ``market`` (so the live socket/session doesn't leak on a failed
+        # startup path) but must NOT call ``disconnect`` on the
+        # never-connected news provider. Disconnect order is intentional:
+        # news first (reverse of connect order), then market.
+        news_connected = False
         try:
+            if upstream_news is not None:
+                await upstream_news.connect()
+                news_connected = True
             await _capture_floats(upstream_float, recorder, symbols, as_of, real_clock)
             tasks: list[asyncio.Task[None]] = [
                 asyncio.create_task(_capture_quotes(market, recorder, symbols)),
@@ -117,9 +125,10 @@ async def capture_session(
                 await asyncio.gather(*tasks, return_exceptions=True)
                 raise
         finally:
-            await market.disconnect()
-            if upstream_news is not None:
+            if news_connected:
+                assert upstream_news is not None  # noqa: S101  # guarded by flag
                 await upstream_news.disconnect()
+            await market.disconnect()
 
 
 def _validate_timeframes(

--- a/tests/integration/test_capture_session.py
+++ b/tests/integration/test_capture_session.py
@@ -1,0 +1,212 @@
+"""Integration test for the live capture composition (#87).
+
+Drives a flaky :class:`MarketDataProvider` through :func:`capture_session`,
+then replays the resulting recording back through :func:`replay_day` and
+asserts the FEED_GAP rung surfaces end-to-end -- closing the production
+side of the loop that PR #86 opened on the replay side.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import select
+
+from ross_trading.core.clock import VirtualClock
+from ross_trading.core.errors import FeedDisconnected
+from ross_trading.data.capture import capture_session
+from ross_trading.data.market_feed import Timeframe
+from ross_trading.data.types import Bar, FloatRecord, Quote, Tape
+from ross_trading.journal.engine import (
+    create_journal_engine,
+    create_session_factory,
+)
+from ross_trading.journal.models import Base, DecisionKind
+from ross_trading.journal.models import ScannerDecision as ScannerDecisionRow
+from ross_trading.scanner.replay import replay_day
+from tests.fakes.float_ref import FakeFloatReferenceProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+    from pathlib import Path
+
+pytestmark = pytest.mark.integration
+
+
+# Thursday, post-DST, no holiday. Cameron window 12:00-16:00 UTC.
+DAY = date(2025, 1, 2)
+PREV_TRADING_DAY = date(2024, 12, 31)
+WINDOW_OPEN = datetime(2025, 1, 2, 12, 0, tzinfo=UTC)
+
+
+def _passing_d1() -> Bar:
+    return Bar(
+        symbol="AVTX",
+        ts=datetime(
+            PREV_TRADING_DAY.year, PREV_TRADING_DAY.month, PREV_TRADING_DAY.day,
+            21, 0, tzinfo=UTC,
+        ),
+        timeframe="D1",
+        open=Decimal("5.00"), high=Decimal("5.00"),
+        low=Decimal("5.00"), close=Decimal("5.00"),
+        volume=1_000_000,
+    )
+
+
+def _passing_m1(offset_s: int = 0) -> Bar:
+    return Bar(
+        symbol="AVTX",
+        ts=WINDOW_OPEN + timedelta(seconds=offset_s),
+        timeframe="M1",
+        open=Decimal("5.00"), high=Decimal("5.55"),
+        low=Decimal("4.95"), close=Decimal("5.50"),
+        volume=5_000_000,
+    )
+
+
+def _passing_quote() -> Quote:
+    return Quote(
+        symbol="AVTX", ts=WINDOW_OPEN,
+        bid=Decimal("5.49"), ask=Decimal("5.51"),
+        bid_size=500, ask_size=500,
+    )
+
+
+def _passing_float() -> FloatRecord:
+    return FloatRecord(
+        ticker="AVTX", as_of=DAY,
+        float_shares=8_500_000, shares_outstanding=12_000_000,
+        source="test",
+    )
+
+
+class _FlakyDayMarket:
+    """Yields one M1 bar, drops the bar stream once with backfilled bars,
+    then resumes -- exercises the production gap-capture path.
+    """
+
+    def __init__(self) -> None:
+        # Two bars: drop fires after the first yield; the wrapper reconnects
+        # and the second bar arrives in the resumed stream so the gap window
+        # contains both the marker and the recovered bar.
+        self._remaining_m1 = [_passing_m1(0), _passing_m1(60)]
+        self._d1 = [_passing_d1()]
+        self._quotes = [_passing_quote()]
+        self._dropped = False
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+
+    @property
+    def supported_timeframes(self) -> frozenset[Timeframe]:
+        return frozenset({Timeframe.M1, Timeframe.D1})
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+
+    async def subscribe_quotes(self, symbols: Iterable[str]) -> AsyncIterator[Quote]:
+        del symbols
+        for q in self._quotes:
+            yield q
+
+    async def subscribe_bars(
+        self, symbols: Iterable[str], timeframe: Timeframe,
+    ) -> AsyncIterator[Bar]:
+        del symbols
+        if timeframe is Timeframe.D1:
+            for b in self._d1:
+                yield b
+            return
+        # M1 stream: emit one bar, then drop, then nothing else.
+        emitted = 0
+        while self._remaining_m1:
+            if not self._dropped and emitted == 1:
+                self._dropped = True
+                raise FeedDisconnected("websocket-closed")
+            yield self._remaining_m1.pop(0)
+            emitted += 1
+
+    async def subscribe_tape(self, symbols: Iterable[str]) -> AsyncIterator[Tape]:
+        del symbols
+        if False:
+            yield  # pragma: no cover
+
+    async def historical_bars(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        timeframe: Timeframe,
+    ) -> Sequence[Bar]:
+        del symbol, start, end, timeframe
+        return ()
+
+
+async def test_capture_then_replay_emits_feed_gap_decision(tmp_path: Path) -> None:
+    """End-to-end: capture a flaky session, then replay -> journal must
+    contain a FEED_GAP decision row sourced from the captured gap file."""
+    recordings = tmp_path / "recordings"
+    universe_dir = tmp_path / "universe"
+    universe_dir.mkdir()
+    (universe_dir / f"{DAY.isoformat()}.json").write_text(
+        json.dumps(["AVTX"]), encoding="utf-8",
+    )
+
+    upstream = _FlakyDayMarket()
+    float_provider = FakeFloatReferenceProvider(
+        records={("AVTX", DAY): _passing_float()},
+    )
+    # VirtualClock keeps gap.end stamps inside the test day so replay's
+    # day-window filter accepts the recorded gap.
+    capture_clock = VirtualClock(WINDOW_OPEN)
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=None,
+        upstream_float=float_provider,
+        universe=["AVTX"],
+        output_dir=recordings,
+        timeframes=(Timeframe.M1, Timeframe.D1),
+        as_of=DAY,
+        clock=capture_clock,
+    )
+
+    # The capture path wrote both the bar and the feed_gap to disk.
+    gap_path = recordings / DAY.isoformat() / "feed_gap.jsonl.gz"
+    assert gap_path.exists()
+    bar_path = recordings / DAY.isoformat() / "bar.jsonl.gz"
+    assert bar_path.exists()
+    float_path = recordings / DAY.isoformat() / "float.jsonl.gz"
+    assert float_path.exists()
+
+    engine = create_journal_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    try:
+        await replay_day(
+            day=DAY,
+            recordings_dir=recordings,
+            universe_dir=universe_dir,
+            journal_engine=engine,
+        )
+        session_factory = create_session_factory(engine)
+        with session_factory() as session:
+            gap_rows = session.execute(
+                select(ScannerDecisionRow).where(
+                    ScannerDecisionRow.kind == DecisionKind.FEED_GAP,
+                ),
+            ).scalars().all()
+    finally:
+        engine.dispose()
+
+    assert len(gap_rows) == 1
+    row = gap_rows[0]
+    assert row.ticker is None
+    assert row.reason is not None
+    assert row.gap_start is not None
+    assert row.gap_end is not None
+    assert row.gap_start <= row.gap_end

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -1,0 +1,334 @@
+"""Unit tests for the live capture composition (#87).
+
+The composition wires a ``MarketDataProvider`` (and optional news / float
+providers) behind :class:`ReconnectingProvider` and pipes every event into
+a :class:`FeedRecorder`. These tests cover per-stream round-trip and the
+optional-provider branches; the integration test covers the gap loop.
+"""
+
+from __future__ import annotations
+
+import gzip
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ross_trading.core.errors import FeedDisconnected, FeedError
+from ross_trading.data.capture import capture_session
+from ross_trading.data.market_feed import Timeframe
+from ross_trading.data.types import (
+    Bar,
+    FloatRecord,
+    Headline,
+    Quote,
+    Side,
+    Tape,
+)
+from tests.fakes.float_ref import FakeFloatReferenceProvider
+from tests.fakes.market import FakeMarketDataProvider
+from tests.fakes.news import FakeNewsProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable, Sequence
+    from pathlib import Path
+
+T0 = datetime(2026, 5, 4, 13, 30, tzinfo=UTC)
+DAY = date(2026, 5, 4)
+
+
+def _quote(symbol: str, offset: int) -> Quote:
+    return Quote(
+        symbol=symbol,
+        ts=T0 + timedelta(seconds=offset),
+        bid=Decimal("1.00"),
+        ask=Decimal("1.01"),
+        bid_size=100,
+        ask_size=100,
+    )
+
+
+def _bar(symbol: str, offset: int, timeframe: str = "M1") -> Bar:
+    return Bar(
+        symbol=symbol,
+        ts=T0 + timedelta(seconds=offset),
+        timeframe=timeframe,
+        open=Decimal("1.00"),
+        high=Decimal("1.05"),
+        low=Decimal("0.95"),
+        close=Decimal("1.02"),
+        volume=10_000,
+    )
+
+
+def _tape(symbol: str, offset: int) -> Tape:
+    return Tape(
+        symbol=symbol,
+        ts=T0 + timedelta(seconds=offset),
+        price=Decimal("1.00"),
+        size=100,
+        side=Side.BUY,
+    )
+
+
+def _headline(symbol: str, offset: int) -> Headline:
+    return Headline(
+        ticker=symbol,
+        ts=T0 + timedelta(seconds=offset),
+        source="Benzinga",
+        title=f"{symbol} headline {offset}",
+    )
+
+
+def _float(symbol: str) -> FloatRecord:
+    return FloatRecord(
+        ticker=symbol,
+        as_of=DAY,
+        float_shares=8_500_000,
+        shares_outstanding=12_000_000,
+        source="test",
+    )
+
+
+def _read_gz_lines(path: Path) -> list[str]:
+    with gzip.open(path, "rt", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+async def test_capture_records_quotes_and_bars(tmp_path: Path) -> None:
+    upstream = FakeMarketDataProvider(
+        quotes=[_quote("AVTX", 0), _quote("AVTX", 1)],
+        bars=[_bar("AVTX", 0), _bar("AVTX", 60)],
+    )
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=None,
+        upstream_float=None,
+        universe=["AVTX"],
+        output_dir=tmp_path,
+        timeframes=(Timeframe.M1,),
+    )
+    assert upstream.connect_calls == 1
+    assert upstream.disconnect_calls == 1
+    assert len(_read_gz_lines(tmp_path / DAY.isoformat() / "quote.jsonl.gz")) == 2
+    assert len(_read_gz_lines(tmp_path / DAY.isoformat() / "bar.jsonl.gz")) == 2
+
+
+async def test_capture_subscribes_each_requested_timeframe(tmp_path: Path) -> None:
+    upstream = FakeMarketDataProvider(
+        bars=[
+            _bar("AVTX", 0, "M1"),
+            _bar("AVTX", 60, "M1"),
+            _bar("AVTX", 0, "D1"),
+        ],
+        timeframes=(Timeframe.M1, Timeframe.D1),
+    )
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=None,
+        upstream_float=None,
+        universe=["AVTX"],
+        output_dir=tmp_path,
+        timeframes=(Timeframe.M1, Timeframe.D1),
+    )
+    bar_lines = _read_gz_lines(tmp_path / DAY.isoformat() / "bar.jsonl.gz")
+    assert len(bar_lines) == 3
+
+
+async def test_capture_records_tape(tmp_path: Path) -> None:
+    upstream = FakeMarketDataProvider(
+        tape=[_tape("AVTX", 0), _tape("AVTX", 1), _tape("BBAI", 2)],
+    )
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=None,
+        upstream_float=None,
+        universe=["AVTX", "BBAI"],
+        output_dir=tmp_path,
+        timeframes=(Timeframe.M1,),
+    )
+    assert len(_read_gz_lines(tmp_path / DAY.isoformat() / "tape.jsonl.gz")) == 3
+
+
+async def test_capture_records_headlines_when_news_provider_given(
+    tmp_path: Path,
+) -> None:
+    upstream = FakeMarketDataProvider()
+    news = FakeNewsProvider(
+        headlines=[_headline("AVTX", 0), _headline("AVTX", 5)]
+    )
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=news,
+        upstream_float=None,
+        universe=["AVTX"],
+        output_dir=tmp_path,
+        timeframes=(Timeframe.M1,),
+    )
+    assert news.connect_calls == 1
+    assert news.disconnect_calls == 1
+    assert len(_read_gz_lines(tmp_path / DAY.isoformat() / "headline.jsonl.gz")) == 2
+
+
+async def test_capture_skips_news_when_provider_is_none(tmp_path: Path) -> None:
+    upstream = FakeMarketDataProvider()
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=None,
+        upstream_float=None,
+        universe=["AVTX"],
+        output_dir=tmp_path,
+        timeframes=(Timeframe.M1,),
+    )
+    assert not (tmp_path / DAY.isoformat() / "headline.jsonl.gz").exists()
+
+
+async def test_capture_records_floats_when_float_provider_given(
+    tmp_path: Path,
+) -> None:
+    upstream = FakeMarketDataProvider()
+    float_provider = FakeFloatReferenceProvider(
+        records={("AVTX", DAY): _float("AVTX"), ("BBAI", DAY): _float("BBAI")}
+    )
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=None,
+        upstream_float=float_provider,
+        universe=["AVTX", "BBAI"],
+        output_dir=tmp_path,
+        timeframes=(Timeframe.M1,),
+        as_of=DAY,
+    )
+    assert sorted(float_provider.calls) == [("AVTX", DAY), ("BBAI", DAY)]
+    assert len(_read_gz_lines(tmp_path / DAY.isoformat() / "float.jsonl.gz")) == 2
+
+
+async def test_capture_tolerates_missing_float_record(tmp_path: Path) -> None:
+    upstream = FakeMarketDataProvider()
+    float_provider = FakeFloatReferenceProvider(
+        records={("AVTX", DAY): _float("AVTX")}  # ZZZZ deliberately missing
+    )
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=None,
+        upstream_float=float_provider,
+        universe=["AVTX", "ZZZZ"],
+        output_dir=tmp_path,
+        timeframes=(Timeframe.M1,),
+        as_of=DAY,
+    )
+    # AVTX was recorded; ZZZZ raised FeedError and was skipped without
+    # crashing the capture session.
+    assert len(_read_gz_lines(tmp_path / DAY.isoformat() / "float.jsonl.gz")) == 1
+
+
+async def test_capture_records_feed_gap_on_reconnect(tmp_path: Path) -> None:
+    """Capture composition wires recorder behind the reconnect provider, so a
+    disconnect/reconnect cycle persists a ``feed_gap`` row to disk."""
+
+    class _FlakyMarket:
+        @property
+        def supported_timeframes(self) -> frozenset[Timeframe]:
+            return frozenset({Timeframe.M1})
+
+        def __init__(self) -> None:
+            self._remaining_bars = [_bar("AVTX", 0), _bar("AVTX", 60)]
+            self._dropped = False
+            self.connect_calls = 0
+            self.disconnect_calls = 0
+
+        async def connect(self) -> None:
+            self.connect_calls += 1
+
+        async def disconnect(self) -> None:
+            self.disconnect_calls += 1
+
+        async def subscribe_quotes(
+            self, symbols: Iterable[str]
+        ) -> AsyncIterator[Quote]:
+            del symbols
+            if False:
+                yield  # pragma: no cover
+
+        async def subscribe_bars(
+            self, symbols: Iterable[str], timeframe: Timeframe
+        ) -> AsyncIterator[Bar]:
+            del symbols, timeframe
+            emitted = 0
+            while self._remaining_bars:
+                if not self._dropped and emitted == 1:
+                    self._dropped = True
+                    raise FeedDisconnected("websocket-closed")
+                yield self._remaining_bars.pop(0)
+                emitted += 1
+
+        async def subscribe_tape(
+            self, symbols: Iterable[str]
+        ) -> AsyncIterator[Tape]:
+            del symbols
+            if False:
+                yield  # pragma: no cover
+
+        async def historical_bars(
+            self,
+            symbol: str,
+            start: datetime,
+            end: datetime,
+            timeframe: Timeframe,
+        ) -> Sequence[Bar]:
+            del symbol, start, end, timeframe
+            return ()
+
+    upstream = _FlakyMarket()
+    await capture_session(
+        upstream_market_data=upstream,
+        upstream_news=None,
+        upstream_float=None,
+        universe=["AVTX"],
+        output_dir=tmp_path,
+        timeframes=(Timeframe.M1,),
+    )
+    gap_path = tmp_path / DAY.isoformat() / "feed_gap.jsonl.gz"
+    assert gap_path.exists()
+    gap_lines = _read_gz_lines(gap_path)
+    assert len(gap_lines) == 1
+    bar_lines = _read_gz_lines(tmp_path / DAY.isoformat() / "bar.jsonl.gz")
+    assert len(bar_lines) == 2  # both bars survived the disconnect+reconnect
+
+
+async def test_capture_rejects_unsupported_timeframe(tmp_path: Path) -> None:
+    upstream = FakeMarketDataProvider(timeframes=(Timeframe.M1,))
+    with pytest.raises(ValueError, match="not supported"):
+        await capture_session(
+            upstream_market_data=upstream,
+            upstream_news=None,
+            upstream_float=None,
+            universe=["AVTX"],
+            output_dir=tmp_path,
+            timeframes=(Timeframe.S10,),
+        )
+
+
+async def test_capture_propagates_unrelated_errors(tmp_path: Path) -> None:
+    """A non-FeedDisconnected error from a stream surfaces; capture does not hang."""
+
+    class _ExplodingMarket(FakeMarketDataProvider):
+        async def subscribe_quotes(
+            self, symbols: Iterable[str]
+        ) -> AsyncIterator[Quote]:
+            del symbols
+            msg = "boom"
+            raise FeedError(msg)
+            yield  # pragma: no cover
+
+    upstream = _ExplodingMarket()
+    with pytest.raises(FeedError, match="boom"):
+        await capture_session(
+            upstream_market_data=upstream,
+            upstream_news=None,
+            upstream_float=None,
+            universe=["AVTX"],
+            output_dir=tmp_path,
+            timeframes=(Timeframe.M1,),
+        )

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -171,6 +171,59 @@ async def test_capture_records_headlines_when_news_provider_given(
     assert len(_read_gz_lines(tmp_path / DAY.isoformat() / "headline.jsonl.gz")) == 2
 
 
+async def test_capture_disconnects_market_when_news_connect_fails(
+    tmp_path: Path,
+) -> None:
+    """If ``news.connect`` raises, the already-connected market provider must
+    still be disconnected (no leaked socket on a failed startup path), and the
+    never-connected news provider must NOT have ``disconnect`` called on it.
+    """
+
+    class _FailingNews:
+        def __init__(self) -> None:
+            self.connect_calls = 0
+            self.disconnect_calls = 0
+
+        async def connect(self) -> None:
+            self.connect_calls += 1
+            msg = "news-credentials-down"
+            raise FeedError(msg)
+
+        async def disconnect(self) -> None:
+            self.disconnect_calls += 1
+
+        async def subscribe_headlines(
+            self, symbols: Iterable[str] | None = None
+        ) -> AsyncIterator[Headline]:
+            del symbols
+            if False:
+                yield  # pragma: no cover
+
+        async def recent_headlines(
+            self, symbol: str, since: datetime
+        ) -> Sequence[Headline]:
+            del symbol, since
+            return ()
+
+    upstream = FakeMarketDataProvider()
+    news = _FailingNews()
+    with pytest.raises(FeedError, match="news-credentials-down"):
+        await capture_session(
+            upstream_market_data=upstream,
+            upstream_news=news,
+            upstream_float=None,
+            universe=["AVTX"],
+            output_dir=tmp_path,
+            timeframes=(Timeframe.M1,),
+        )
+    # Market connected then was cleaned up despite the news connect failure.
+    assert upstream.connect_calls == 1
+    assert upstream.disconnect_calls == 1
+    # News provider never finished connecting, so disconnect must NOT run.
+    assert news.connect_calls == 1
+    assert news.disconnect_calls == 0
+
+
 async def test_capture_skips_news_when_provider_is_none(tmp_path: Path) -> None:
     upstream = FakeMarketDataProvider()
     await capture_session(


### PR DESCRIPTION
## Summary

Adds `ross_trading.data.capture.capture_session` — vendor-agnostic glue that runs a live `MarketDataProvider` (with optional `NewsProvider` / `FloatReferenceProvider`) through `ReconnectingProvider(upstream, on_gap=recorder.record_feed_gap)` and pipes every event into a `FeedRecorder`. Closes the production-side half of the FEED_GAP loop that PR #86 opened on the replay side.

Closes #87

## What changed

- `src/ross_trading/data/capture.py` (new) — `capture_session()` entry point. Snapshots floats once at session start, then fans out concurrent capture tasks for quotes, tape, bars per requested timeframe, and (if provided) headlines. Tasks run under `asyncio.gather` with a manual cancel-and-drain on first failure so the underlying error propagates unwrapped (`asyncio.TaskGroup` would wrap it in `ExceptionGroup`). Recorder lifecycle is bound to the function via an async context.
- `tests/unit/test_capture.py` (new) — per-stream coverage (quotes, bars per timeframe, tape, headlines, floats), optional-provider branches, per-ticker `FeedError` tolerance on float fetch, the reconnect gap-capture path, the unsupported-timeframe guard, and unrelated-error propagation.
- `tests/integration/test_capture_session.py` (new) — drives a flaky upstream through `capture_session`, replays the resulting recording back via `replay_day`, and asserts the journal contains a `FEED_GAP` decision row sourced from the captured `feed_gap.jsonl.gz` — the end-to-end parity test the issue's AC requires.

## Acceptance criteria (from #87)

- [x] New module with `capture_session` entry point under full mypy `--strict`.
- [x] When upstream raises `FeedDisconnected` and recovers, `feed_gap.jsonl.gz` contains the corresponding `FeedGap` row.
- [x] Quotes / bars / tape / headlines / floats round-trip through the recorder.
- [x] Backfilled bars from `ReconnectingProvider.historical_bars` after reconnect are written via `record_bar`, leaving the recording internally consistent.
- [x] Integration test: capture-with-disconnect → replay → journal contains a `FEED_GAP` decision row matching the recorded gap.
- [x] No new runtime dependency.
- [x] mypy `--strict`, ruff, pytest all green.

## Test evidence

- `python -m pytest tests/unit/test_capture.py tests/integration/test_capture_session.py -q` → **11 passed**
- `python -m pytest -q` → **377 passed**
- `python -m ruff check src/ tests/` → **All checks passed**
- `python -m mypy` → **Success: no issues found in 84 source files**

## Risk and rollback notes

- Pure addition: no existing module/test was modified. New tests pass cleanly against the existing reconnect/recorder/replay code.
- Production side hasn't yet wired any vendor adapter through `capture_session` — that's deferred until #11 (market data feed decision) lands. This PR can be reverted with a single `git revert` and removes only the new files, with no follow-on cleanup needed.
- Termination semantics: `capture_session` returns when every stream is exhausted (true for finite fakes in tests) or on cancellation (the production model). No deadline / max-duration knob — production deployments cancel the surrounding task to stop, matching the issue's "out of scope: CLI daemon wrapper."