### PR TITLE
fix: add historical intraday backfill path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ python -m ross_trading.journal.report --date YYYY-MM-DD
 
 See [`docs/architecture.md`](docs/architecture.md) for the full design (modules, decision logic, validation approach, resolved decisions).
 
+## Docs
+
+- [`docs/ground_truth.md`](docs/ground_truth.md) — curator workflow for the hand-labelled oracle
+- [`docs/historical-data.md`](docs/historical-data.md) — backfill bar recordings from Alpha Vantage CSV
+- [`docs/drift-control.md`](docs/drift-control.md) — Drift CI severity rules and waiver process
+
 ## Plans
 
 In-flight implementation plans live in [`plans/`](plans/); merged plans are archived under [`plans/archive/`](plans/archive/).

--- a/docs/ground_truth.md
+++ b/docs/ground_truth.md
@@ -56,6 +56,8 @@ Unknown keys raise `GroundTruthError` (e.g., `"note"` for `"notes"` is rejected)
 
 ## Procedure
 
+Before curating new days, pre-populate the bar recordings for those dates using [`scripts/backfill_historical.py`](../scripts/backfill_historical.py) — see [`docs/historical-data.md`](historical-data.md) for the full backfill workflow.
+
 1. Identify the trading day. Confirm the recap exists and is from Cameron (not a Warrior staff trader's recap).
 2. Watch the recap end-to-end. Take linear notes — ticker, time, what he did, why.
 3. For each entered ticker, write one record per the schema. Keep `notes` brief — one sentence — but unambiguous about why this counts as "actively-called".

--- a/docs/historical-data.md
+++ b/docs/historical-data.md
@@ -1,0 +1,116 @@
+# Historical Intraday Data
+
+Phase 2 replay uses the local recorder format consumed by
+`ross_trading.data.providers.replay.ReplayProvider`:
+
+```text
+recordings/
+  YYYY-MM-DD/
+    bar.jsonl.gz
+```
+
+Each line is a schema-versioned JSON envelope written by `FeedRecorder`. The
+backfill path below writes only `bar` events: `M1` intraday bars for the target
+trading days and `D1` bars for the trailing baseline window. That is enough for
+the #74 replay driver to run without its synthetic fallback and for the scanner
+to compute price change and 30-day relative volume from recorded data.
+
+## Chosen OS / Free-Tier Path
+
+Use Alpha Vantage's CSV HTTP endpoints:
+
+* `TIME_SERIES_INTRADAY` with `interval=1min`, `adjusted=false`,
+  `extended_hours=true`, `month=YYYY-MM`, `outputsize=full`, `datatype=csv`.
+* `TIME_SERIES_DAILY` with `outputsize=full`, `datatype=csv` for the daily
+  volume baseline.
+
+Alpha Vantage documents 1-minute intraday history with a `month` selector and
+CSV output, including extended hours. A free API key is available, but usage is
+subject to Alpha Vantage's terms of service and rate limits. Do not commit API
+keys or downloaded vendor data unless the applicable license permits repository
+redistribution.
+
+Primary docs:
+
+* https://www.alphavantage.co/documentation/
+* https://www.alphavantage.co/support/#api-key
+* https://www.alphavantage.co/terms_of_service/
+
+## Fetch Steps
+
+Install the project first:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Set an API key:
+
+```bash
+export ALPHA_VANTAGE_API_KEY=...
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:ALPHA_VANTAGE_API_KEY = "..."
+```
+
+Backfill every currently curated ground-truth ticker/date:
+
+```bash
+python scripts/backfill_historical.py `
+  --ground-truth-dir ground_truth `
+  --recordings-dir recordings
+```
+
+Backfill an explicit day/ticker set:
+
+```bash
+python scripts/backfill_historical.py `
+  --date 2026-05-01 `
+  --symbol AVTX `
+  --symbol MSTR `
+  --recordings-dir recordings
+```
+
+The script throttles requests for the free tier by default. Use `--dry-run` to
+validate API access and parsing without writing files. Use `--overwrite` only
+when intentionally replacing existing `bar.jsonl.gz` files for the fetched
+dates and daily-baseline window.
+
+## Replay Check
+
+After backfill, create a replay universe directory whose files are plain JSON
+ticker lists, for example `replay_universe/2026-05-01.json`:
+
+```json
+["AVTX", "MSTR"]
+```
+
+Then run:
+
+```bash
+python -m ross_trading.scanner.replay `
+  --date 2026-05-01 `
+  --source recordings `
+  --universe-dir replay_universe `
+  --db-url sqlite:///journal.sqlite
+```
+
+`ground_truth/YYYY-MM-DD.json` is an array of objects, not a plain ticker list,
+so pass a separate replay universe directory until the recall runner owns that
+conversion.
+
+## Gaps
+
+* The repository currently has only one curated day in `ground_truth/`; the
+  Phase 2 target remains at least 10 human-curated trading days.
+* This backfill path does not fetch quotes, tape prints, headlines, float, or
+  halt/gap events. The replay assembler falls back to bar close when quotes are
+  absent, but missing float/news data can still suppress picks or reduce mimic
+  fidelity.
+* Alpha Vantage free-tier rate limits make large multi-symbol backfills slow.
+* The script is capable of creating the required recording files when a valid
+  API key and source coverage are available, but this PR does not commit vendor
+  recordings or fabricate historical data.

--- a/scripts/backfill_historical.py
+++ b/scripts/backfill_historical.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
+import gzip
 import json
 import os
 import sys
@@ -31,6 +32,7 @@ from urllib.parse import urlencode
 from urllib.request import urlopen
 from zoneinfo import ZoneInfo
 
+from ross_trading.data._codec import EventType, decode_bar, decode_envelope
 from ross_trading.data.recorder import FeedRecorder
 from ross_trading.data.types import Bar, Timeframe
 
@@ -180,11 +182,38 @@ def _resolve_request(args: argparse.Namespace) -> BackfillRequest:
     return BackfillRequest(symbols=frozenset(symbols), days=tuple(sorted(days)))
 
 
-def _overwrite_bar_files(recordings_dir: Path, days: Iterable[date]) -> None:
+def _read_bar_file(path: Path) -> list[Bar]:
+    if not path.exists():
+        return []
+    bars: list[Bar] = []
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            event_type, payload = decode_envelope(line)
+            if event_type != EventType.BAR:
+                msg = f"unexpected event type in {path}: {event_type.value}"
+                raise ValueError(msg)
+            bars.append(decode_bar(payload))
+    return bars
+
+
+def _prepare_overwrite_bars(
+    recordings_dir: Path,
+    days: Iterable[date],
+    symbols: Iterable[str],
+    new_bars: Sequence[Bar],
+) -> list[Bar]:
+    overwrite_symbols = frozenset(symbol.upper() for symbol in symbols)
+    preserved: list[Bar] = []
     for day in days:
         path = recordings_dir / day.isoformat() / "bar.jsonl.gz"
+        preserved.extend(
+            bar for bar in _read_bar_file(path) if bar.symbol.upper() not in overwrite_symbols
+        )
         if path.exists():
             path.unlink()
+    return [*preserved, *new_bars]
 
 
 def _daily_window(days: Sequence[date], lookback_days: int) -> tuple[date, date]:
@@ -344,7 +373,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.dry_run:
         return 0
     if args.overwrite:
-        _overwrite_bar_files(args.recordings_dir, affected_days)
+        bars = _prepare_overwrite_bars(
+            args.recordings_dir,
+            affected_days,
+            request.symbols,
+            bars,
+        )
     asyncio.run(write_bars(args.recordings_dir, bars))
     return 0
 

--- a/scripts/backfill_historical.py
+++ b/scripts/backfill_historical.py
@@ -1,0 +1,353 @@
+"""Backfill replay recordings from free/open HTTP CSV sources.
+
+Current source: Alpha Vantage ``TIME_SERIES_INTRADAY`` + ``TIME_SERIES_DAILY``
+CSV endpoints. The script writes the same gzip JSONL envelopes consumed by
+``ReplayProvider``:
+
+    recordings/<YYYY-MM-DD>/bar.jsonl.gz
+
+No third-party dependency is required; network access is via ``urllib`` and
+CSV parsing uses the standard library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from datetime import time as dt_time
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import urlopen
+from zoneinfo import ZoneInfo
+
+from ross_trading.data.recorder import FeedRecorder
+from ross_trading.data.types import Bar, Timeframe
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
+ET = ZoneInfo("America/New_York")
+DEFAULT_API_KEY_ENV = "ALPHA_VANTAGE_API_KEY"
+
+
+@dataclass(frozen=True, slots=True)
+class BackfillRequest:
+    symbols: frozenset[str]
+    days: tuple[date, ...]
+
+
+def _parse_csv(text: str) -> list[dict[str, str]]:
+    reader = csv.DictReader(text.splitlines())
+    if reader.fieldnames is None:
+        msg = "CSV response has no header"
+        raise ValueError(msg)
+    if "timestamp" not in reader.fieldnames:
+        # Alpha Vantage error/rate-limit responses may arrive as CSV-looking
+        # one-column text. Surface the first line without printing secrets.
+        first = text.splitlines()[0] if text.splitlines() else "<empty response>"
+        msg = f"unexpected CSV header from source: {first}"
+        raise ValueError(msg)
+    return list(reader)
+
+
+def parse_alpha_vantage_intraday_csv(
+    text: str,
+    *,
+    symbol: str,
+    wanted_days: Iterable[date],
+    timeframe: Timeframe = Timeframe.M1,
+) -> list[Bar]:
+    """Parse Alpha Vantage intraday CSV rows into UTC ``Bar`` objects."""
+    wanted = frozenset(wanted_days)
+    bars: list[Bar] = []
+    for row in _parse_csv(text):
+        local_ts = datetime.strptime(row["timestamp"], "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=ET,
+        )
+        if local_ts.date() not in wanted:
+            continue
+        bars.append(
+            Bar(
+                symbol=symbol.upper(),
+                ts=local_ts.astimezone(UTC),
+                timeframe=timeframe.value,
+                open=Decimal(row["open"]),
+                high=Decimal(row["high"]),
+                low=Decimal(row["low"]),
+                close=Decimal(row["close"]),
+                volume=int(row["volume"]),
+            )
+        )
+    bars.sort(key=lambda b: b.ts)
+    return bars
+
+
+def parse_alpha_vantage_daily_csv(
+    text: str,
+    *,
+    symbol: str,
+    start: date,
+    end_exclusive: date,
+) -> list[Bar]:
+    """Parse Alpha Vantage daily CSV rows into UTC D1 ``Bar`` objects."""
+    bars: list[Bar] = []
+    for row in _parse_csv(text):
+        day = date.fromisoformat(row["timestamp"])
+        if not (start <= day < end_exclusive):
+            continue
+        close_et = datetime.combine(day, dt_time(16, 0), tzinfo=ET)
+        bars.append(
+            Bar(
+                symbol=symbol.upper(),
+                ts=close_et.astimezone(UTC),
+                timeframe=Timeframe.D1.value,
+                open=Decimal(row["open"]),
+                high=Decimal(row["high"]),
+                low=Decimal(row["low"]),
+                close=Decimal(row["close"]),
+                volume=int(row["volume"]),
+            )
+        )
+    bars.sort(key=lambda b: b.ts)
+    return bars
+
+
+async def write_bars(recordings_dir: Path, bars: Sequence[Bar]) -> None:
+    """Write bars through ``FeedRecorder`` so replay encoding stays canonical."""
+    async with FeedRecorder(recordings_dir) as recorder:
+        for bar in sorted(bars, key=lambda b: (b.ts, b.symbol, b.timeframe)):
+            recorder.record_bar(bar)
+
+
+def _alpha_vantage_csv(params: dict[str, str]) -> str:
+    url = f"{ALPHA_VANTAGE_URL}?{urlencode(params)}"
+    try:
+        with urlopen(url, timeout=30) as response:  # noqa: S310 - fixed HTTPS source.
+            data = cast("bytes", response.read())
+            return data.decode("utf-8-sig")
+    except HTTPError as exc:
+        msg = f"Alpha Vantage HTTP {exc.code} for {params.get('function')}"
+        raise RuntimeError(msg) from exc
+    except URLError as exc:
+        msg = f"Alpha Vantage request failed: {exc.reason}"
+        raise RuntimeError(msg) from exc
+
+
+def _month_key(day: date) -> str:
+    return f"{day.year:04d}-{day.month:02d}"
+
+
+def _load_ground_truth_request(path: Path) -> BackfillRequest:
+    symbols: set[str] = set()
+    days: list[date] = []
+    for file in sorted(path.glob("*.json")):
+        day = date.fromisoformat(file.stem)
+        rows = json.loads(file.read_text(encoding="utf-8"))
+        if not isinstance(rows, list):
+            msg = f"{file} must contain a JSON list"
+            raise ValueError(msg)
+        for row in rows:
+            symbols.add(str(row["ticker"]).upper())
+        days.append(day)
+    return BackfillRequest(symbols=frozenset(symbols), days=tuple(days))
+
+
+def _resolve_request(args: argparse.Namespace) -> BackfillRequest:
+    symbols = {s.upper() for s in args.symbol}
+    days = {date.fromisoformat(d) for d in args.date}
+    if args.ground_truth_dir is not None:
+        from_ground_truth = _load_ground_truth_request(args.ground_truth_dir)
+        symbols.update(from_ground_truth.symbols)
+        days.update(from_ground_truth.days)
+    if not symbols:
+        msg = "no symbols supplied; pass --symbol or --ground-truth-dir"
+        raise SystemExit(msg)
+    if not days:
+        msg = "no dates supplied; pass --date or --ground-truth-dir"
+        raise SystemExit(msg)
+    return BackfillRequest(symbols=frozenset(symbols), days=tuple(sorted(days)))
+
+
+def _overwrite_bar_files(recordings_dir: Path, days: Iterable[date]) -> None:
+    for day in days:
+        path = recordings_dir / day.isoformat() / "bar.jsonl.gz"
+        if path.exists():
+            path.unlink()
+
+
+def _daily_window(days: Sequence[date], lookback_days: int) -> tuple[date, date]:
+    first = min(days) - timedelta(days=lookback_days)
+    last_exclusive = max(days) + timedelta(days=1)
+    return first, last_exclusive
+
+
+def fetch_alpha_vantage_bars(
+    request: BackfillRequest,
+    *,
+    api_key: str,
+    daily_lookback_days: int,
+    throttle_seconds: float,
+) -> list[Bar]:
+    bars: list[Bar] = []
+    days_by_month: dict[str, list[date]] = defaultdict(list)
+    for day in request.days:
+        days_by_month[_month_key(day)].append(day)
+
+    for symbol in sorted(request.symbols):
+        for month, month_days in sorted(days_by_month.items()):
+            text = _alpha_vantage_csv(
+                {
+                    "function": "TIME_SERIES_INTRADAY",
+                    "symbol": symbol,
+                    "interval": "1min",
+                    "adjusted": "false",
+                    "extended_hours": "true",
+                    "month": month,
+                    "outputsize": "full",
+                    "datatype": "csv",
+                    "apikey": api_key,
+                }
+            )
+            bars.extend(
+                parse_alpha_vantage_intraday_csv(
+                    text,
+                    symbol=symbol,
+                    wanted_days=month_days,
+                )
+            )
+            if throttle_seconds > 0:
+                time.sleep(throttle_seconds)
+
+        start, end_exclusive = _daily_window(request.days, daily_lookback_days)
+        text = _alpha_vantage_csv(
+            {
+                "function": "TIME_SERIES_DAILY",
+                "symbol": symbol,
+                "outputsize": "full",
+                "datatype": "csv",
+                "apikey": api_key,
+            }
+        )
+        bars.extend(
+            parse_alpha_vantage_daily_csv(
+                text,
+                symbol=symbol,
+                start=start,
+                end_exclusive=end_exclusive,
+            )
+        )
+        if throttle_seconds > 0:
+            time.sleep(throttle_seconds)
+    return bars
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Backfill replay bar recordings from Alpha Vantage CSV data.",
+    )
+    parser.add_argument(
+        "--recordings-dir",
+        type=Path,
+        default=Path("recordings"),
+        help="Replay recordings root (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--ground-truth-dir",
+        type=Path,
+        help="Read symbols and dates from ground_truth/*.json.",
+    )
+    parser.add_argument(
+        "--date",
+        action="append",
+        default=[],
+        help="Trading date YYYY-MM-DD. May be passed more than once.",
+    )
+    parser.add_argument(
+        "--symbol",
+        action="append",
+        default=[],
+        help="Ticker to fetch. May be passed more than once.",
+    )
+    parser.add_argument(
+        "--api-key",
+        help=f"Alpha Vantage API key. Defaults to ${DEFAULT_API_KEY_ENV}.",
+    )
+    parser.add_argument(
+        "--api-key-env",
+        default=DEFAULT_API_KEY_ENV,
+        help="Environment variable containing the API key (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--daily-lookback-days",
+        type=int,
+        default=45,
+        help="Calendar days of D1 bars to write before the first target date.",
+    )
+    parser.add_argument(
+        "--throttle-seconds",
+        type=float,
+        default=12.5,
+        help="Delay between API calls for free-tier rate limits.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace existing bar.jsonl.gz files for affected dates.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and parse, but do not write recordings.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    request = _resolve_request(args)
+    api_key = args.api_key or os.environ.get(args.api_key_env)
+    if not api_key:
+        msg = f"missing Alpha Vantage key; pass --api-key or set {args.api_key_env}"
+        raise SystemExit(msg)
+    bars = fetch_alpha_vantage_bars(
+        request,
+        api_key=api_key,
+        daily_lookback_days=args.daily_lookback_days,
+        throttle_seconds=args.throttle_seconds,
+    )
+    target_days = set(request.days)
+    daily_start, daily_end = _daily_window(request.days, args.daily_lookback_days)
+    affected_days = {
+        b.ts.astimezone(UTC).date()
+        for b in bars
+        if b.timeframe == Timeframe.M1.value or daily_start <= b.ts.date() < daily_end
+    }
+    intraday_count = sum(1 for b in bars if b.timeframe == Timeframe.M1.value)
+    daily_count = sum(1 for b in bars if b.timeframe == Timeframe.D1.value)
+    print(
+        f"parsed bars: intraday={intraday_count} daily={daily_count} "
+        f"symbols={len(request.symbols)} target_days={len(target_days)}",
+        file=sys.stderr,
+    )
+    if args.dry_run:
+        return 0
+    if args.overwrite:
+        _overwrite_bar_files(args.recordings_dir, affected_days)
+    asyncio.run(write_bars(args.recordings_dir, bars))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_backfill_historical.py
+++ b/tests/unit/test_backfill_historical.py
@@ -5,6 +5,8 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+import pytest
+
 from ross_trading.data._codec import decode_bar, decode_envelope
 from ross_trading.data.types import Timeframe
 from scripts.backfill_historical import (
@@ -60,6 +62,7 @@ def test_parse_alpha_vantage_daily_csv_writes_market_close_utc() -> None:
     assert all(b.timeframe == Timeframe.D1.value for b in bars)
 
 
+@pytest.mark.integration
 async def test_write_bars_uses_replay_recording_shape(tmp_path: Path) -> None:
     bars = parse_alpha_vantage_intraday_csv(
         INTRADAY_CSV,
@@ -79,6 +82,7 @@ async def test_write_bars_uses_replay_recording_shape(tmp_path: Path) -> None:
     assert decode_bar(payload) == bars[0]
 
 
+@pytest.mark.integration
 async def test_prepare_overwrite_bars_preserves_other_symbols(tmp_path: Path) -> None:
     existing_target = parse_alpha_vantage_intraday_csv(
         INTRADAY_CSV,

--- a/tests/unit/test_backfill_historical.py
+++ b/tests/unit/test_backfill_historical.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from ross_trading.data._codec import decode_bar, decode_envelope
 from ross_trading.data.types import Timeframe
 from scripts.backfill_historical import (
+    _prepare_overwrite_bars,
     parse_alpha_vantage_daily_csv,
     parse_alpha_vantage_intraday_csv,
     write_bars,
@@ -76,3 +77,38 @@ async def test_write_bars_uses_replay_recording_shape(tmp_path: Path) -> None:
     event_type, payload = decode_envelope(lines[0])
     assert event_type.value == "bar"
     assert decode_bar(payload) == bars[0]
+
+
+async def test_prepare_overwrite_bars_preserves_other_symbols(tmp_path: Path) -> None:
+    existing_target = parse_alpha_vantage_intraday_csv(
+        INTRADAY_CSV,
+        symbol="AVTX",
+        wanted_days={date(2026, 5, 1)},
+    )
+    existing_other = parse_alpha_vantage_intraday_csv(
+        INTRADAY_CSV,
+        symbol="BBAI",
+        wanted_days={date(2026, 5, 1)},
+    )
+    await write_bars(tmp_path, [*existing_target, *existing_other])
+
+    replacement = parse_alpha_vantage_intraday_csv(
+        "timestamp,open,high,low,close,volume\n"
+        "2026-05-01 07:32:00,4.20,4.40,4.10,4.35,2500\n",
+        symbol="AVTX",
+        wanted_days={date(2026, 5, 1)},
+    )
+
+    bars = _prepare_overwrite_bars(
+        tmp_path,
+        {date(2026, 5, 1)},
+        {"AVTX"},
+        replacement,
+    )
+    await write_bars(tmp_path, bars)
+
+    path = tmp_path / "2026-05-01" / "bar.jsonl.gz"
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        decoded = [decode_bar(decode_envelope(line)[1]) for line in handle if line.strip()]
+    assert [bar.symbol for bar in decoded] == ["BBAI", "BBAI", "AVTX"]
+    assert decoded[-1].ts == datetime(2026, 5, 1, 11, 32, tzinfo=UTC)

--- a/tests/unit/test_backfill_historical.py
+++ b/tests/unit/test_backfill_historical.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import gzip
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from ross_trading.data._codec import decode_bar, decode_envelope
+from ross_trading.data.types import Timeframe
+from scripts.backfill_historical import (
+    parse_alpha_vantage_daily_csv,
+    parse_alpha_vantage_intraday_csv,
+    write_bars,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+INTRADAY_CSV = """timestamp,open,high,low,close,volume
+2026-05-01 07:30:00,4.00,4.20,3.90,4.10,1000
+2026-05-01 07:31:00,4.10,4.30,4.05,4.25,2000
+2026-05-02 07:30:00,5.00,5.20,4.90,5.10,3000
+"""
+
+DAILY_CSV = """timestamp,open,high,low,close,volume
+2026-04-30,3.50,3.80,3.40,3.70,500000
+2026-05-01,4.00,4.30,3.90,4.25,700000
+2026-05-02,4.20,4.50,4.10,4.40,800000
+"""
+
+
+def test_parse_alpha_vantage_intraday_csv_filters_days_and_converts_et_to_utc() -> None:
+    bars = parse_alpha_vantage_intraday_csv(
+        INTRADAY_CSV,
+        symbol="avtx",
+        wanted_days={date(2026, 5, 1)},
+    )
+
+    assert [b.symbol for b in bars] == ["AVTX", "AVTX"]
+    assert [b.timeframe for b in bars] == [Timeframe.M1.value, Timeframe.M1.value]
+    assert bars[0].ts == datetime(2026, 5, 1, 11, 30, tzinfo=UTC)
+    assert bars[0].close == Decimal("4.10")
+    assert bars[1].volume == 2000
+
+
+def test_parse_alpha_vantage_daily_csv_writes_market_close_utc() -> None:
+    bars = parse_alpha_vantage_daily_csv(
+        DAILY_CSV,
+        symbol="MSTR",
+        start=date(2026, 4, 30),
+        end_exclusive=date(2026, 5, 2),
+    )
+
+    assert [b.ts for b in bars] == [
+        datetime(2026, 4, 30, 20, 0, tzinfo=UTC),
+        datetime(2026, 5, 1, 20, 0, tzinfo=UTC),
+    ]
+    assert all(b.timeframe == Timeframe.D1.value for b in bars)
+
+
+async def test_write_bars_uses_replay_recording_shape(tmp_path: Path) -> None:
+    bars = parse_alpha_vantage_intraday_csv(
+        INTRADAY_CSV,
+        symbol="AVTX",
+        wanted_days={date(2026, 5, 1)},
+    )
+
+    await write_bars(tmp_path, bars)
+
+    path = tmp_path / "2026-05-01" / "bar.jsonl.gz"
+    assert path.exists()
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        lines = [line.strip() for line in handle if line.strip()]
+    assert len(lines) == 2
+    event_type, payload = decode_envelope(lines[0])
+    assert event_type.value == "bar"
+    assert decode_bar(payload) == bars[0]


### PR DESCRIPTION
## Summary
- document Alpha Vantage free-tier CSV path for replay/training intraday backfill
- add no-dependency backfill script that writes ReplayProvider-compatible bar recordings
- add unit coverage for CSV parsing and recorder-format writes

## Tests
- python -m pytest tests\unit\test_backfill_historical.py tests\unit\test_recorder_replay.py
- python -m ruff check scripts\backfill_historical.py tests\unit\test_backfill_historical.py
- python -m mypy scripts\backfill_historical.py
- python -m pytest tests\integration\test_scanner_replay.py tests\integration\test_replay_day.py

## Caveats
- Does not commit vendor recordings or fabricate historical data.
- Current ground_truth/ coverage is one curated day, so the >=10-day recall gate still needs more human-curated days and actual API backfill.
- Bar-only backfill omits quotes, tape, news, float, and halt/gap events; this supports replay without synthetic ticks but remains partial fidelity.

Fixes seanyofthedead/Ross-trading#78