### PR TITLE
docs(plans): add execution build wave plan + handoff

### DIFF
--- a/plans/waves/HANDOFF.md
+++ b/plans/waves/HANDOFF.md
@@ -1,0 +1,124 @@
+# Handoff — execution build context & rationale
+
+This file carries the *reasoning* behind `plans/waves/` so an implementer (human or a fresh
+Claude Code run) starts with the decisions already made, not a blank slate. The wave files
+say **what** to build; this says **why**, and what was explicitly rejected.
+
+It is the distilled output of a two-philosophy design review (a "pragmatist" lens —
+ship-soon, operable, reversible — and a "purist" lens — correctness/integrity before a
+dollar moves) plus a broker debate and a live-data-ingestion analysis.
+
+## Kickoff prompt (paste into Claude Code)
+
+```
+Read plans/waves/README.md and plans/waves/HANDOFF.md for context and the loop contract,
+then implement the lowest-numbered wave whose dependencies are done, on a new feature branch.
+Start with WAVE-00. Work task-by-task, keep mypy --strict / ruff / pytest green, and stop at
+the wave's advance_gate for review before moving on.
+```
+
+## State of the system (as of this review)
+
+- Phase 2: a live **scanner + journaling** system works. The execution path is **specified
+  but unbuilt** — `docs/architecture.md` §3.5–§3.8 and §4 are prose/pseudocode; there is no
+  order routing, broker client, position/PnL ledger, risk supervisor, or reconciliation in
+  code. `src/ross_trading/safety/` is an empty package.
+- The journal (`journal/models.py`) persists scanner decisions only — **no orders/fills/
+  positions/PnL tables**.
+- Strong correctness discipline already exists and should be reused, not disturbed: the
+  `SnapshotAssembler` determinism boundary and D6 replay-parity contract, `Decimal`-
+  everywhere, frozen/slotted value objects, and the journal's `BEGIN IMMEDIATE` + WAL +
+  FK/CheckConstraint rigor (`journal/engine.py`). **That rigor stops exactly where money
+  starts — closing that gap is the whole point of these waves.**
+- No market-data **recordings** exist in either repo (`recordings/` is gitignored and empty;
+  the research repo's `data/` holds only the YouTube-transcript corpus). This is decision
+  #78. Real recordings first appear when the paid feed is wired (Wave 6).
+
+## The core decisions (and why)
+
+### 1. Build order: correctness foundation before features
+Both lenses agreed the riskiest, least-retrofittable work is the **write path** (duplicate
+sends, lost fills, position drift) and the **ingestion contract** (silent drop/reorder
+corrupting the as-of snapshot). So the waves front-load those:
+
+- **Wave 0 (ingestion contract)** comes first because the architecture's entire thesis is
+  bit-identical live/replay, yet `Quote`/`Tape`/`Bar` carry **no sequence numbers** and gaps
+  are detected **only on socket disconnect** (`data/reconnect.py`). A feed that silently
+  drops a message produces no gap sentinel and the assembler picks the wrong as-of value —
+  on *any* vendor. Fix the contract (seq numbers, three-timestamp split, seq-discontinuity
+  gap detection, typed halts, append-only corrections) before anything trusts the snapshot.
+- **Wave 1 (ledger) before Wave 2 (broker)**: lock the order/fill/position model, state
+  machine, and `client_order_id` idempotency against a fake first, so the broker adapter is
+  built against a correct internal model — not the reverse. This was the purist's "ledger-
+  first" point; the pragmatist's "broker-first" instinct is honored by resolving the broker
+  choice now (below) so the port is shaped by a real API.
+- **Wave 3 (kill switch) early**: it's the blast-radius limiter and currently an empty
+  package; everything after it runs under a supervisor that can stop it.
+- **Wave 4 (reconciliation)** makes the kill switch *trustworthy* — force-flatten is
+  meaningless if the bot's notion of position can silently diverge from the broker's.
+
+**Must-do-before-live:** Waves 0, 1, 3, 4 and the Wave 6 parity gate. The rest (real L2,
+the 10-sec micro-pullback, regime calibration) is later hardening.
+
+### 2. Broker: Alpaca to start, with two non-negotiable guardrails
+The pragmatist picked Alpaca (fast, commission-free at micro-stakes, native brackets, free
+paper, sits behind a swappable port). The purist picked IBKR (authoritative queryable
+order/position state). The split **resolved** once the purist surfaced a load-bearing fact:
+**Alpaca's order-update WebSocket has no sequence numbers** — Alpaca's own docs say events
+can drop/reorder and recommend FIX for guaranteed delivery. So "Alpaca" is only safe with:
+
+1. **Do not trust the JSON WebSocket as position-state truth.** Use FIX for order events, or
+   treat the WS as a hint with REST `/orders` + `/positions` authoritative (Wave 4
+   reconciliation enforces this).
+2. **Pay for full-SIP data from day one.** The scanner's first hard filter is relative-volume
+   ≥5×, computed on total market volume. Alpaca's free tier is IEX-only (~2% of volume) and
+   venue-biased — wrong for exactly the low-float small-caps this strategy trades. IEX-only
+   is **rejected** as the signal source (Wave 6).
+
+The broker sits behind a clean `BrokerClient` port (Wave 2) so the agreed upgrade to **IBKR**
+(execution) and/or **Databento** (signal data) is a drop-in when a switch trigger fires.
+
+### 3. Data ingestion shape (Wave 0 + Wave 5/6)
+- Hybrid transport: WebSocket streaming for quotes/M1 bars/halts; once-daily REST for D1
+  baseline and float.
+- Two consumers, one buffer: the ~2s scanner loop reads the **assembled as-of snapshot**
+  (unchanged); the **exit monitor subscribes to the quote stream + broker order-event stream
+  directly** and reacts on arrival — **never polls** for fill state, never waits for the 2s
+  tick to hit a hard stop (Wave 5).
+- As-of selection by `(exchange_ts, seq)`, completed bars only (`is_final`), gaps explicit —
+  the existing record-forward → replay path makes this provable.
+
+## Switch triggers (the at-scale upgrade path — documented, not yet built)
+
+Move execution to **IBKR** and/or signal data to **Databento** when any fire:
+
+- The live-vs-replay parity test can't be made to pass on Alpaca's unsequenced market-data WS.
+- The §3.7 **real L2-weakness exit** gets built (needs MBP-10 depth — until then use the
+  spread+size **proxy**).
+- Measured live slippage on low-float fills consistently exceeds the simulator.
+- **Pre-market** Gap-and-Go entries become core (Alpaca brackets are RTH-only / TIF DAY|GTC).
+- Float can't be confirmed refreshing daily pre-07:00 ET → add a float vendor (Polygon
+  reference / Benzinga), decision #33 — the one second-vendor likely unavoidable.
+
+## What was explicitly rejected / deferred
+
+- **IEX-only / free data** as the signal source — correctness failure for low-float rel-vol.
+- **Alpaca order JSON WebSocket as truth** — no sequence numbers; FIX or REST-reconcile only.
+- **Buying Databento now** — nothing consumes L2/tape yet; premature. Keep the port clean and
+  add it on a trigger.
+- **Building detectors before the execution skeleton** — the repo's next planned atom was the
+  `EntrySignal` value object; these waves intentionally resequence the ledger/kill-switch/
+  reconciliation ahead of more detector work, since that's where the unguarded money risk is.
+
+## Open decision-issues these waves resolve
+
+#10 broker (Alpaca-with-guardrails, IBKR on trigger) · #11 data feed (paid full SIP) ·
+#12 L2 (proxy now, MBP-10 on trigger) · #33 float daily refresh (verify, add vendor if
+needed) · #78 recordings (first real recordings appear at Wave 6).
+
+## Provenance
+
+Derived from a design-review session over both repos. The factual file:line citations live
+in the individual wave files; `docs/architecture.md` (§3.5–§3.8, §4, D6) and
+`.claude/decision-issues.json` are the upstream sources. The reviews themselves were not
+committed — this file is their durable residue.

--- a/plans/waves/README.md
+++ b/plans/waves/README.md
@@ -1,0 +1,48 @@
+# Execution build — wave plan (loop runner)
+
+These waves turn the trade-execution design review into large, dependency-ordered units
+you can run one-at-a-time in a Claude Code loop. Each `WAVE-NN-*.md` is self-contained:
+goal, scope, files, key interfaces, acceptance criteria, tasks, test strategy, an
+**advance gate**, and a **paste-ready prompt**.
+
+They are deliberately *larger* than the repo's per-atom plans (e.g.
+`plans/phase-4-pattern-detector-a1-entry-signal.md`). A wave is a coherent shippable
+slice; inside a wave, the implementing agent may still work atom-by-atom.
+
+## Loop contract
+
+Each file has YAML frontmatter:
+
+```yaml
+wave: 0
+depends_on: []           # wave ids that must be `status: done` first
+advance_gate: "..."      # the objective condition to mark this wave done
+status: not_started      # not_started | in_progress | done
+```
+
+A driver loop should:
+
+1. Pick the lowest-numbered wave whose `status != done` **and** every `depends_on` is `done`.
+2. Paste that wave's **"Claude Code prompt"** block into a fresh Claude Code run.
+3. Let it implement task-by-task on a feature branch.
+4. When the **advance gate** passes (CI green + the named test), flip `status: done` and loop.
+
+## Order & gates (summary)
+
+| Wave | Title | Depends on | Advance gate (short) |
+|---|---|---|---|
+| 0 | Ingestion contract correctness | — | `(ts,seq)` ordering + seq-gap detection + halt/correction events; live-vs-replay parity test green |
+| 1 | Execution domain model & ledger | 0 | orders/fills/positions tables + state machine + idempotency, migration applies, unit tests green |
+| 2 | Broker port + Fake + paper adapter | 1 | `BrokerClient` Protocol + `FakeBroker` + `AlpacaPaperBroker`; idempotent `submit_bracket`; contract tests green |
+| 3 | Risk supervisor / kill switch | 1 | `safety/` enforces max-loss, loser-lock, single-position, PDT/T+1; force-flatten; loop-gated; tests green |
+| 4 | Reconciliation (broker truth) | 2, 3 | startup + cadence reconcile ledger vs broker; divergence → kill switch; recovery test green |
+| 5 | Live signal→order wiring + event-driven exits | 2, 3, 4 | trading + position-management loops wired; exits consume order-event + quote streams (no polling); sizer Decimal/int; integration tests green on FakeBroker |
+| 6 | Go-live gate: paid SIP data, parity CI, paper soak | 0, 5 | full-SIP feed wired; bit-identical live-vs-replay CI gate enforced; float daily-refresh verified; micro-stakes paper soak runbook |
+
+**Must-do-before-live:** Waves 0–6 in order. Waves 0, 1, 3, 4 and the Wave 6 parity gate are
+the non-negotiable correctness/safety set. Everything tagged "later hardening" inside a wave
+can ship after first live capital.
+
+> This is a READ-of-review → BUILD plan. The reviews it derives from:
+> `docs/architecture.md` (§3.5–§3.8, D6), `.claude/decision-issues.json` (#10 broker,
+> #11 data feed, #12 L2, #33 float cadence, #78 recordings).

--- a/plans/waves/WAVE-00-ingestion-contract.md
+++ b/plans/waves/WAVE-00-ingestion-contract.md
@@ -16,7 +16,7 @@ status: not_started
 
 ## Decisions carried in (from the review)
 
-- **Order by `(ts, seq)`, dedup on `seq`.** Sorting on `ts` alone is non-deterministic on ties and cannot detect dupes/reorders. The single highest-value change.
+- **Order by `(ts, seq)`, dedup on the scoped `(ticker, channel, seq)` key.** Sorting on `ts` alone is non-deterministic on ties and cannot detect dupes/reorders; `seq` is only monotonic per `(ticker, channel)`, so the dedup key must carry that scope. The single highest-value change.
 - **Three timestamps, not one.** Persist `exchange_ts` (participant/exchange), `vendor_ts` (vendor send) and `ingest_ts` (local receipt). All *as-of* logic keys off `exchange_ts`; staleness/watermark keys off `ingest_ts`. The codec already records two (`data/_codec.py` `ts`/`ts_recorded`) — formalize three.
 - **Gaps from sequence discontinuity, not socket lifecycle.** `ReconnectingProvider` currently emits `FeedGap` only on `FeedDisconnected` (`data/reconnect.py`). A silent drop must still surface a `FeedGap` via per-channel seq discontinuity.
 - **Halts are a typed event.** Add a `Halt` event distinct from `FeedGap`; trading the resume off a stale pre-halt `last` is a real-money error.
@@ -38,7 +38,7 @@ Out: brokers, orders, execution, risk, reconciliation (Waves 1+). No new data ve
 | Edit | `src/ross_trading/data/recorder.py` | Persist new fields/events; corrections as append-only deltas with audit fields. |
 | Edit | `src/ross_trading/data/reconnect.py` | Per-channel seq tracking; emit `FeedGap` on seq discontinuity; emit/propagate `Halt`. |
 | Edit | `src/ross_trading/data/market_feed.py` | Extend `MarketDataProvider` protocol with halt subscription + seq contract docs. |
-| Edit | `src/ross_trading/scanner/assembler.py` | As-of selection orders/dedups by `(exchange_ts, seq)`; refuse to bridge gap/halt sentinels. |
+| Edit | `src/ross_trading/scanner/assembler.py` | As-of selection orders by `(exchange_ts, seq)`, dedups on `(ticker, channel, seq)`; refuse to bridge gap/halt sentinels. |
 | Edit | `src/ross_trading/scanner/replay.py` | `_last_at_or_before` keys on `(exchange_ts, seq)`; reproduce halts/corrections deterministically. |
 | Edit | `src/ross_trading/data/providers/replay.py` | Replay emits new fields/events in recorded order. |
 | Edit | `src/ross_trading/scanner/loop.py` | Staleness uses `ingest_ts`; distinguish stale-feed vs halt vs gap. |
@@ -84,7 +84,7 @@ class Correction:                # also covers busts (qty/price -> 0 == bust)
 ## Acceptance criteria
 
 - [ ] `Quote`/`Tape`/`Bar` carry `seq` + the three timestamps; all `Decimal` prices, `int` volume, tz-aware UTC datetimes; no `float`.
-- [ ] Assembler and replay select as-of by `(exchange_ts, seq)` and dedup on `seq`; identical inputs in any arrival order produce identical snapshots.
+- [ ] Assembler and replay order as-of by `(exchange_ts, seq)` and dedup on a scoped `(ticker, channel, seq)` key — `seq` is only monotonic per `(ticker, channel)`, so de-duping on bare `seq` would discard valid events when different symbols/channels reuse the same number; identical inputs in any arrival order produce identical snapshots.
 - [ ] A dropped seq (e.g. 1,2,4) surfaces a `FeedGap` for that channel even with the socket up; detectors refuse to bridge it.
 - [ ] `Halt`/resume is a typed event, distinct from `FeedGap`; a resume does not fire entries off a pre-halt stale `last`.
 - [ ] A `Correction`/bust adjusts recorded volume via append-only delta; original + corrected both visible in the recording; rel-vol reflects the correction deterministically in replay.
@@ -104,7 +104,7 @@ Drive the assembler with a hand-built event stream that is (a) shuffled in arriv
 - [ ] 2a. **Back-compat:** keep all v1 decoders, version-dispatch in `decode_envelope`, synthesize defaults for v1 payloads; add `tests/unit/test_codec_backcompat.py` with a captured v1 fixture.
 - [ ] 2b. **Migration:** write idempotent `scripts/upgrade_recordings_v1_to_v2.py` for any on-disk recordings; document it (a one-liner in `README.md`/`docs/` on when to run it).
 - [ ] 3. Add per-channel seq tracking + discontinuity gap detection + halt propagation in `reconnect.py`.
-- [ ] 4. Make assembler + replay order/dedup on `(exchange_ts, seq)` and honor halt/correction sentinels.
+- [ ] 4. Make assembler + replay order on `(exchange_ts, seq)` and dedup on `(ticker, channel, seq)`, honoring halt/correction sentinels.
 - [ ] 5. Point staleness at `ingest_ts`; separate stale/halt/gap handling in `loop.py`.
 - [ ] 6. Write the parity integration test + unit contract tests.
 - [ ] 7. ruff / mypy --strict / pytest green; CI green on feature branch.
@@ -115,7 +115,8 @@ Drive the assembler with a hand-built event stream that is (a) shuffled in arriv
 Implement plans/waves/WAVE-00-ingestion-contract.md in the ross-trading repo, on a new
 feature branch. This is the ingestion-correctness wave: add per-message sequence numbers
 and a three-way timestamp split to Quote/Tape/Bar; make the SnapshotAssembler and the
-replay path order and dedup strictly on (exchange_ts, seq); detect feed gaps from
+replay path order strictly on (exchange_ts, seq) and dedup on the scoped
+(ticker, channel, seq) key; detect feed gaps from
 sequence discontinuity rather than only on socket disconnect; add a typed Halt event and
 an append-only Correction/bust path. Follow the repo's existing conventions (frozen
 slotted dataclasses, Decimal prices, tz-aware UTC, mypy --strict, ruff, pytest), mirroring

--- a/plans/waves/WAVE-00-ingestion-contract.md
+++ b/plans/waves/WAVE-00-ingestion-contract.md
@@ -1,0 +1,137 @@
+---
+wave: 0
+title: Ingestion contract correctness
+depends_on: []
+advance_gate: "Quote/Tape/Bar carry (exchange_ts, vendor_ts, ingest_ts, seq); assembler + replay order/dedup on (ts, seq); gap detection fires on sequence discontinuity (not just socket disconnect); typed Halt + correction/bust events exist; a live-vs-replay bit-identical decision test passes; codec is SCHEMA_VERSION 2 with v1 still supported and a v1 fixture decoding/replaying under the v2 build; an idempotent recordings v1->v2 upgrade script exists; mypy --strict + ruff + pytest green on a feature branch."
+status: not_started
+---
+
+# Wave 0 — Ingestion contract correctness
+
+> **For agentic workers:** implement task-by-task; steps use `- [ ]` checkboxes. READ-of-review → BUILD. Stay inside the file scope below; do not start broker/execution work (that is Wave 1+).
+
+**Goal:** Make the live-data ingestion path *provably reproducible* before any real dollar depends on it. The `SnapshotAssembler` is already the single determinism boundary (`docs/architecture.md` D6, `scanner/assembler.py`), but it can only be as reproducible as its inputs — and today the inputs are leaky: `Quote`/`Tape`/`Bar` carry **no sequence number** (`data/types.py`), gaps are detected **only on socket disconnect** (`data/reconnect.py`), halts are indistinguishable from gaps, and there is no path for trade corrections/busts. This wave closes those four holes so live/replay is bit-identical by construction on any vendor.
+
+**Why first:** Every later wave (orders, exits, reconciliation, the go-live parity gate) trusts that the snapshot a decision was made on is faithfully recorded and replayable. If a feed can silently drop or reorder ticks and the system can't tell, that trust is unfounded regardless of which broker or data vendor is chosen.
+
+## Decisions carried in (from the review)
+
+- **Order by `(ts, seq)`, dedup on `seq`.** Sorting on `ts` alone is non-deterministic on ties and cannot detect dupes/reorders. The single highest-value change.
+- **Three timestamps, not one.** Persist `exchange_ts` (participant/exchange), `vendor_ts` (vendor send) and `ingest_ts` (local receipt). All *as-of* logic keys off `exchange_ts`; staleness/watermark keys off `ingest_ts`. The codec already records two (`data/_codec.py` `ts`/`ts_recorded`) — formalize three.
+- **Gaps from sequence discontinuity, not socket lifecycle.** `ReconnectingProvider` currently emits `FeedGap` only on `FeedDisconnected` (`data/reconnect.py`). A silent drop must still surface a `FeedGap` via per-channel seq discontinuity.
+- **Halts are a typed event.** Add a `Halt` event distinct from `FeedGap`; trading the resume off a stale pre-halt `last` is a real-money error.
+- **Corrections/busts are first-class, append-only.** A late print or busted trade must adjust recorded volume via an append-only delta with audit trail — never an in-place overwrite — so rel-vol can't be silently corrupted.
+- **Recording back-compat is mandatory, not optional.** Changing `Quote`/`Tape`/`Bar` changes the on-disk wire format (`data/_codec.py`, `SCHEMA_VERSION = 1`). Bump to `SCHEMA_VERSION = 2`, keep `1` in `SUPPORTED_SCHEMA_VERSIONS`, and keep every v1 decoder forever — the codec's own docstring already commits to "decoders must dispatch on the version field and accept old payloads forever." A v1 payload (no `seq`/three-ts/halt/correction) must decode by synthesizing deterministic defaults (`seq` derived from file order, `exchange_ts = vendor_ts = ts`, `ingest_ts = ts_recorded`), so old recordings still replay bit-identically to how they replayed under v1. `recordings/` is gitignored and currently empty (decision #78), so there may be nothing on disk yet — but the forward-decodability contract must hold regardless, and an offline upgrade script is provided for any recordings that do exist.
+
+## Scope
+
+In: `data/types.py`, `data/_codec.py`, `data/recorder.py`, `data/reconnect.py`, `data/market_feed.py` (protocol), `data/providers/replay.py`, `scanner/assembler.py`, `scanner/replay.py`, `scanner/loop.py` (staleness), one new migration only if recordings schema is versioned on disk, tests.
+Out: brokers, orders, execution, risk, reconciliation (Waves 1+). No new data vendor integration here — this is contract + plumbing, validated against existing/replay + fakes.
+
+## Files to add / change
+
+| Action | Path | Purpose |
+|---|---|---|
+| Edit | `src/ross_trading/data/types.py` | Add `seq: int`, `exchange_ts`/`vendor_ts`/`ingest_ts` to `Quote`/`Tape`/`Bar`; add `Halt` event; add `Correction`/`Bust` event types. |
+| Edit | `src/ross_trading/data/_codec.py` | Bump to `SCHEMA_VERSION = 2`; add `2` to `SUPPORTED_SCHEMA_VERSIONS` (keep `1`); add `EventType.HALT`/`CORRECTION`; **keep v1 decoders** and version-dispatch so v1 payloads upgrade with synthesized defaults. |
+| Create | `scripts/upgrade_recordings_v1_to_v2.py` | Offline, idempotent batch upgrade of any existing `recordings/**.jsonl.gz` from v1→v2 (synthesize `seq`/three-ts; non-destructive, writes alongside or to a versioned dir; re-runnable). |
+| Edit | `src/ross_trading/data/recorder.py` | Persist new fields/events; corrections as append-only deltas with audit fields. |
+| Edit | `src/ross_trading/data/reconnect.py` | Per-channel seq tracking; emit `FeedGap` on seq discontinuity; emit/propagate `Halt`. |
+| Edit | `src/ross_trading/data/market_feed.py` | Extend `MarketDataProvider` protocol with halt subscription + seq contract docs. |
+| Edit | `src/ross_trading/scanner/assembler.py` | As-of selection orders/dedups by `(exchange_ts, seq)`; refuse to bridge gap/halt sentinels. |
+| Edit | `src/ross_trading/scanner/replay.py` | `_last_at_or_before` keys on `(exchange_ts, seq)`; reproduce halts/corrections deterministically. |
+| Edit | `src/ross_trading/data/providers/replay.py` | Replay emits new fields/events in recorded order. |
+| Edit | `src/ross_trading/scanner/loop.py` | Staleness uses `ingest_ts`; distinguish stale-feed vs halt vs gap. |
+| Create | `tests/integration/test_live_replay_parity.py` | Bit-identical decisions from a synthetic out-of-order/dropped/halted/corrected stream vs its replay. |
+| Create | `tests/unit/test_ingestion_contract.py` | seq dedup/order, three-ts, gap-on-discontinuity, halt typing, correction deltas. |
+| Create | `tests/unit/test_codec_backcompat.py` | A captured v1 fixture line decodes under the v2 build; round-trip + synthesized-default assertions; v2 encodes/decodes; unsupported version still raises. |
+
+## Key interfaces (sketch)
+
+```python
+# data/types.py
+@dataclass(frozen=True, slots=True)
+class Quote:
+    ticker: str
+    bid: Decimal
+    ask: Decimal
+    seq: int            # per-(ticker,channel) monotonic vendor sequence
+    exchange_ts: datetime
+    vendor_ts: datetime
+    ingest_ts: datetime
+    # ... existing fields
+
+@dataclass(frozen=True, slots=True)
+class Halt:
+    ticker: str
+    state: Literal["halted", "resumed"]
+    reason_code: str | None
+    seq: int
+    exchange_ts: datetime
+    ingest_ts: datetime
+
+@dataclass(frozen=True, slots=True)
+class Correction:                # also covers busts (qty/price -> 0 == bust)
+    ticker: str
+    corrects_seq: int            # the original print being amended
+    new_size: int | None
+    new_price: Decimal | None
+    seq: int
+    exchange_ts: datetime
+    ingest_ts: datetime
+```
+
+## Acceptance criteria
+
+- [ ] `Quote`/`Tape`/`Bar` carry `seq` + the three timestamps; all `Decimal` prices, `int` volume, tz-aware UTC datetimes; no `float`.
+- [ ] Assembler and replay select as-of by `(exchange_ts, seq)` and dedup on `seq`; identical inputs in any arrival order produce identical snapshots.
+- [ ] A dropped seq (e.g. 1,2,4) surfaces a `FeedGap` for that channel even with the socket up; detectors refuse to bridge it.
+- [ ] `Halt`/resume is a typed event, distinct from `FeedGap`; a resume does not fire entries off a pre-halt stale `last`.
+- [ ] A `Correction`/bust adjusts recorded volume via append-only delta; original + corrected both visible in the recording; rel-vol reflects the correction deterministically in replay.
+- [ ] `tests/integration/test_live_replay_parity.py` proves bit-identical decisions live-vs-replay over an adversarial stream (reorder + drop + halt + bust).
+- [ ] **Back-compat:** `SCHEMA_VERSION == 2`, `SUPPORTED_SCHEMA_VERSIONS ⊇ {1, 2}`; a captured v1 recording line decodes under the v2 build via synthesized defaults (`seq` from file order, `exchange_ts = vendor_ts = ts`, `ingest_ts = ts_recorded`) and replays identically to its v1 behavior; an unsupported/future version still raises.
+- [ ] **Upgrade script:** `scripts/upgrade_recordings_v1_to_v2.py` is idempotent and non-destructive (re-running is a no-op; originals recoverable); a v1 fixture upgraded by the script decodes as native v2.
+- [ ] mypy `--strict`, ruff, full pytest green; CI green on the branch.
+
+## Test strategy
+
+Drive the assembler with a hand-built event stream that is (a) shuffled in arrival order, (b) missing a seq, (c) interrupted by a halt/resume, (d) hit by a busted print. Record it, replay it, assert the decision journal is byte-identical. Unit-test each invariant in isolation.
+
+## Tasks
+
+- [ ] 1. Extend `data/types.py` value objects (`seq`, three ts) + add `Halt`, `Correction`.
+- [ ] 2. Update `_codec.py` + `recorder.py` (encode/decode new fields/events, bump to `SCHEMA_VERSION=2`, append-only corrections).
+- [ ] 2a. **Back-compat:** keep all v1 decoders, version-dispatch in `decode_envelope`, synthesize defaults for v1 payloads; add `tests/unit/test_codec_backcompat.py` with a captured v1 fixture.
+- [ ] 2b. **Migration:** write idempotent `scripts/upgrade_recordings_v1_to_v2.py` for any on-disk recordings; document it (a one-liner in `README.md`/`docs/` on when to run it).
+- [ ] 3. Add per-channel seq tracking + discontinuity gap detection + halt propagation in `reconnect.py`.
+- [ ] 4. Make assembler + replay order/dedup on `(exchange_ts, seq)` and honor halt/correction sentinels.
+- [ ] 5. Point staleness at `ingest_ts`; separate stale/halt/gap handling in `loop.py`.
+- [ ] 6. Write the parity integration test + unit contract tests.
+- [ ] 7. ruff / mypy --strict / pytest green; CI green on feature branch.
+
+## Claude Code prompt
+
+```
+Implement plans/waves/WAVE-00-ingestion-contract.md in the ross-trading repo, on a new
+feature branch. This is the ingestion-correctness wave: add per-message sequence numbers
+and a three-way timestamp split to Quote/Tape/Bar; make the SnapshotAssembler and the
+replay path order and dedup strictly on (exchange_ts, seq); detect feed gaps from
+sequence discontinuity rather than only on socket disconnect; add a typed Halt event and
+an append-only Correction/bust path. Follow the repo's existing conventions (frozen
+slotted dataclasses, Decimal prices, tz-aware UTC, mypy --strict, ruff, pytest), mirroring
+the style in scanner/types.py and data/types.py.
+
+These field changes alter the on-disk recording format, so preserve back-compat: in
+data/_codec.py bump SCHEMA_VERSION to 2, keep 1 in SUPPORTED_SCHEMA_VERSIONS, keep every v1
+decoder, and version-dispatch so v1 payloads upgrade with deterministic synthesized defaults
+(seq from file order; exchange_ts = vendor_ts = ts; ingest_ts = ts_recorded) and still
+replay bit-identically to their v1 behavior. Add tests/unit/test_codec_backcompat.py with a
+captured v1 fixture, and write an idempotent, non-destructive
+scripts/upgrade_recordings_v1_to_v2.py for any existing recordings (recordings/ is gitignored
+and may be empty, but the forward-decodability contract must still hold).
+
+Work task-by-task through the Tasks list, checking each box as you go. Do not start any
+broker/order/execution work. Done when the advance_gate in the frontmatter holds: the new
+live-vs-replay parity test passes, v1 recordings still decode/replay under the v2 build, and
+CI is green. Keep docs/architecture.md D6 in lockstep if you change the determinism contract.
+```

--- a/plans/waves/WAVE-01-execution-ledger.md
+++ b/plans/waves/WAVE-01-execution-ledger.md
@@ -1,0 +1,112 @@
+---
+wave: 1
+title: Execution domain model & ledger
+depends_on: [0]
+advance_gate: "orders/fills/positions tables + Alembic migration apply cleanly; Order/Fill/Position value objects (frozen, Decimal) exist; an order state machine (intended->sent->acked->partial->filled/canceled/rejected) is enforced; client_order_id is a unique idempotency key; intent is persisted transactionally (BEGIN IMMEDIATE) before any send; unit tests green; mypy --strict + ruff + pytest green on a feature branch."
+status: not_started
+---
+
+# Wave 1 — Execution domain model & ledger
+
+> **For agentic workers:** implement task-by-task; `- [ ]` checkboxes. Stay in scope; no broker I/O yet (that is Wave 2 — this wave persists *intent* and *state*, validated with an in-memory fake).
+
+**Goal:** Build the write-path correctness foundation **before** any broker call: an order/fill/position ledger with a unique `client_order_id`, a persisted order state machine, and transactional intent-before-send. The current journal models scanner decisions only (`journal/models.py` — picks/watchlist/scanner_decisions); there is no concept of an order, fill, position, or PnL. The hardest correctness problems in a money-mover (duplicate sends, lost fills, position drift) live here, and they must be designed in the way `EntrySignal` was — while changing them is free.
+
+**Why before brokers:** The duplicate-send/lost-fill/drift invariants cannot be retrofitted safely. Locking the ledger and state machine first means the broker adapter (Wave 2) is built against a correct internal model, not the other way round.
+
+## Decisions carried in
+
+- **`client_order_id` is the idempotency key.** Generated and persisted *before* send; a retry/restart re-uses it; the broker dedups on it. Cleaner than relying on broker-assigned ids.
+- **Persist intent before the wire.** Write the `intended` row inside the existing `BEGIN IMMEDIATE` discipline (`journal/engine.py`) *then* (in Wave 2) send. A crash between intent and send is recoverable; a send with no persisted intent is not.
+- **Explicit state machine.** `intended -> sent -> acked -> partial -> filled | canceled | rejected | expired`. Illegal transitions raise. Partial fills accumulate filled/remaining quantity precisely (the §3.5 sizer and §6 capacity cap depend on exact filled qty).
+- **Broker is truth for positions** (enforced in Wave 4); this wave models the *internal* ledger that will be reconciled against it.
+- **Decimal/int end-to-end.** Prices `Decimal`, quantities `int`, no `float` (matches `EntrySignal` / `ScannerPick`).
+
+## Scope
+
+In: a new `execution/` package (value objects + state machine + ledger writer), new journal tables + one Alembic migration, journal models/types edits, unit tests.
+Out: any network/broker call, the `BrokerClient` protocol (Wave 2), risk checks (Wave 3), reconciliation loop (Wave 4), loop wiring (Wave 5).
+
+## Files to add / change
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/ross_trading/execution/__init__.py` | New package. |
+| Create | `src/ross_trading/execution/types.py` | `Order`, `Fill`, `Position`, `OrderState` enum + `OrderStateLit` mirror (frozen, slotted, Decimal). |
+| Create | `src/ross_trading/execution/state_machine.py` | Pure transition function; illegal transitions raise; partial-fill accumulation. |
+| Create | `src/ross_trading/execution/ledger.py` | Transactional writer: persist intent, apply acks/fills/cancels; idempotent on `client_order_id`. |
+| Edit | `src/ross_trading/journal/models.py` | `orders`, `fills`, `positions` tables; unique `client_order_id`; FKs; CheckConstraints (mirror existing rigor). |
+| Edit | `src/ross_trading/journal/types.py` | Persist/read mappings for the new rows. |
+| Create | `src/ross_trading/journal/migrations/versions/<rev>_orders_fills_positions.py` | Alembic migration for the three tables. |
+| Create | `tests/unit/test_execution_state_machine.py` | All legal/illegal transitions, partial accumulation. |
+| Create | `tests/unit/test_execution_ledger.py` | Idempotency on `client_order_id`, intent-before-send ordering, crash-recovery read-back. |
+
+## Key interfaces (sketch)
+
+```python
+# execution/types.py
+class OrderState(enum.Enum):
+    INTENDED = "intended"; SENT = "sent"; ACKED = "acked"
+    PARTIAL = "partial"; FILLED = "filled"
+    CANCELED = "canceled"; REJECTED = "rejected"; EXPIRED = "expired"
+
+@dataclass(frozen=True, slots=True)
+class Order:
+    client_order_id: str          # idempotency key, unique
+    ticker: str
+    side: Literal["buy", "sell"]
+    qty: int
+    limit_price: Decimal | None
+    stop_price: Decimal | None
+    bracket_group_id: str | None  # ties entry+stop+target (OCO) together
+    state: OrderState
+    created_ts: datetime
+    # broker_order_id filled in after ack (Wave 2)
+
+# execution/ledger.py
+class Ledger:
+    def record_intent(self, order: Order) -> None: ...        # BEGIN IMMEDIATE; unique client_order_id
+    def mark_sent(self, client_order_id: str, broker_order_id: str) -> None: ...
+    def apply_fill(self, fill: Fill) -> Position: ...          # accumulates; returns new position
+    def open_orders(self) -> list[Order]: ...                  # for restart recovery (Wave 4)
+    def position(self, ticker: str) -> Position | None: ...
+```
+
+## Acceptance criteria
+
+- [ ] `orders`/`fills`/`positions` tables exist; the migration applies and downgrades cleanly; `client_order_id` is `UNIQUE`.
+- [ ] `record_intent` is idempotent: a second call with the same `client_order_id` is a no-op/raises, never a duplicate row.
+- [ ] State machine enforces legal transitions only; illegal ones raise; partial fills accumulate filled/remaining exactly.
+- [ ] Intent is committed before any "sent" mark; a simulated crash after intent leaves a recoverable `intended` order (read back via `open_orders`).
+- [ ] All prices `Decimal`, quantities `int`; no `float`; rows tz-aware UTC.
+- [ ] mypy `--strict`, ruff, full pytest green; CI green.
+
+## Test strategy
+
+Pure/unit + SQLite-backed ledger tests, no network. Property-style test: any sequence of legal events leaves ledger position == sum of signed fills. Idempotency test: replaying the same intent/fill stream twice yields one set of rows.
+
+## Tasks
+
+- [ ] 1. `execution/types.py` value objects + `OrderState`/`OrderStateLit`.
+- [ ] 2. `execution/state_machine.py` pure transitions + partial accumulation.
+- [ ] 3. journal tables + Alembic migration (mirror engine.py transactional rigor).
+- [ ] 4. `execution/ledger.py` transactional writer, idempotent on `client_order_id`.
+- [ ] 5. Unit tests: state machine, ledger idempotency, intent-before-send, recovery read-back.
+- [ ] 6. ruff / mypy --strict / pytest green; CI green.
+
+## Claude Code prompt
+
+```
+Implement plans/waves/WAVE-01-execution-ledger.md in the ross-trading repo on a new
+feature branch. Build the execution write-path foundation BEFORE any broker code: a new
+execution/ package with Order/Fill/Position value objects (frozen, slotted, Decimal
+prices, int qty), a pure order state machine (intended->sent->acked->partial->
+filled/canceled/rejected/expired with illegal transitions raising and exact partial-fill
+accumulation), and a transactional Ledger that persists order intent (unique
+client_order_id idempotency key) inside the existing BEGIN IMMEDIATE discipline from
+journal/engine.py before anything is "sent". Add orders/fills/positions tables to
+journal/models.py with FKs and CheckConstraints mirroring the existing scanner-decision
+tables, plus one Alembic migration. No network or broker calls in this wave; validate with
+SQLite-backed unit tests. Work task-by-task, checking boxes. Done when the advance_gate
+holds and CI is green.
+```

--- a/plans/waves/WAVE-02-broker-port.md
+++ b/plans/waves/WAVE-02-broker-port.md
@@ -1,0 +1,105 @@
+---
+wave: 2
+title: Broker port + FakeBroker + Alpaca paper adapter
+depends_on: [1]
+advance_gate: "BrokerClient Protocol defined; FakeBroker (deterministic) and AlpacaPaperBroker implemented behind it; idempotent submit_bracket(client_order_id,...) maps the architecture §3.6 atomic OCO bracket; order events consumed via a delivery-guaranteed path (FIX or REST-reconciled, NOT bare JSON WS as source of truth); a shared broker contract test suite passes against both FakeBroker and AlpacaPaperBroker (paper); mypy --strict + ruff + pytest green."
+status: not_started
+---
+
+# Wave 2 — Broker port + FakeBroker + Alpaca paper adapter
+
+> **For agentic workers:** implement task-by-task; `- [ ]` checkboxes. The Ledger (Wave 1) is the source of internal truth; this wave gives it a wire.
+
+**Goal:** Introduce one broker-agnostic seam and two implementations, so the same code path drives a deterministic fake (tests/replay) and a real paper account. Mirror the repo's existing Protocol pattern (`data/market_feed.py::MarketDataProvider`, `scanner/decisions.py::DecisionSink`). The single method that matters is an idempotent `submit_bracket(client_order_id, ...)` that realizes the §3.6 atomic OCO bracket (marketable-limit entry, hard stop, 2:1 limit target, ~50% scale-out).
+
+**Why this shape:** A clean port means the start-here broker (Alpaca) and the agreed at-scale upgrade (IBKR) are drop-in swaps later. It also keeps live and replay parity: `FakeBroker` makes execution deterministically testable without a network.
+
+## Decisions carried in
+
+- **Start on Alpaca paper.** Native bracket/OCO, free paper endpoint mirroring live, REST `/orders`+`/positions` for reconciliation, commission-free at micro-stakes.
+- **Do NOT trust Alpaca's order JSON WebSocket as truth.** It has no sequence numbers (events drop/reorder, per Alpaca's own docs). Consume order updates via **FIX** *or* treat the WS as a hint and make REST `/orders`+`/positions` authoritative (reconciliation lands in Wave 4). The port must allow either transport behind the same interface.
+- **`client_order_id` flows through unchanged** from the Ledger as the broker-side idempotency key.
+- **Bracket caveats are explicit.** Alpaca brackets are RTH-only / TIF DAY|GTC; pre-market Gap-and-Go entries need manual leg management — document this on the adapter and surface it as a capability flag.
+- **Broker is swappable.** Nothing above the port may import an Alpaca symbol; IBKR/others implement the same Protocol later.
+
+## Scope
+
+In: `execution/broker.py` (Protocol + shared value types), `execution/brokers/fake.py`, `execution/brokers/alpaca.py`, a reusable broker **contract test suite** parametrized over implementations, config for keys/endpoints.
+Out: risk checks (Wave 3), the reconciliation loop (Wave 4 — this wave only exposes the query methods it will use), loop wiring (Wave 5), live (non-paper) trading.
+
+## Files to add / change
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/ross_trading/execution/broker.py` | `BrokerClient` Protocol + request/result value objects + `BrokerCapabilities`. |
+| Create | `src/ross_trading/execution/brokers/__init__.py` | Adapter subpackage. |
+| Create | `src/ross_trading/execution/brokers/fake.py` | Deterministic in-memory broker: configurable fills/partials/rejects/latency for tests. |
+| Create | `src/ross_trading/execution/brokers/alpaca.py` | Alpaca paper adapter: submit_bracket, cancel, flatten, query orders/positions; FIX-or-REST order events. |
+| Edit | `src/ross_trading/execution/ledger.py` | Hook broker acks/fills into ledger transitions (`mark_sent`, `apply_fill`). |
+| Create | `tests/contract/test_broker_contract.py` | One suite asserting both adapters honor the Protocol semantics. |
+| Create | `tests/unit/test_fake_broker.py` | Fake's scripted scenarios (partial, reject, dup submit). |
+| Edit | `pyproject.toml` | Add the chosen Alpaca SDK + (if FIX) a FIX engine dep. |
+
+## Key interfaces (sketch)
+
+```python
+# execution/broker.py
+class BrokerClient(Protocol):
+    capabilities: BrokerCapabilities          # supports_native_bracket, rth_only_bracket, order_event_transport
+    def submit_bracket(self, req: BracketRequest) -> BrokerAck: ...   # idempotent on req.client_order_id
+    def cancel(self, client_order_id: str) -> None: ...
+    def flatten(self, ticker: str) -> BrokerAck: ...                  # market exit, used by kill switch (Wave 3)
+    def order_events(self) -> AsyncIterator[OrderEvent]: ...          # FIX seq#'d, or WS hint
+    def get_open_orders(self) -> list[BrokerOrder]: ...               # reconciliation truth (Wave 4)
+    def get_positions(self) -> list[BrokerPosition]: ...              # reconciliation truth (Wave 4)
+
+@dataclass(frozen=True, slots=True)
+class BracketRequest:
+    client_order_id: str
+    ticker: str
+    qty: int
+    entry_limit: Decimal      # marketable-limit
+    stop_price: Decimal
+    target_price: Decimal     # 2:1
+    scale_out_qty: int        # ~50%
+    tif: Literal["day", "gtc"]
+```
+
+## Acceptance criteria
+
+- [ ] `BrokerClient` Protocol defined; nothing above the port imports a vendor symbol.
+- [ ] `submit_bracket` is idempotent on `client_order_id`: a duplicate submit returns the same ack, never two broker orders.
+- [ ] `FakeBroker` can script: full fill, partial-then-fill, reject, cancel, and out-of-order/dropped events — deterministically.
+- [ ] `AlpacaPaperBroker` places a real bracket on the paper account and round-trips order events via FIX or via WS+REST-reconcile (WS alone is never treated as truth).
+- [ ] `BrokerCapabilities` exposes `rth_only_bracket` (true for Alpaca) so callers handle pre-market entries explicitly.
+- [ ] The shared contract suite passes against both adapters; mypy `--strict`, ruff, pytest green; CI green.
+
+## Test strategy
+
+The contract suite is the centerpiece: the same scenarios run against `FakeBroker` (always) and `AlpacaPaperBroker` (paper, behind a network marker/skip). Assert idempotency, bracket leg creation, partial-fill event fidelity, and that querying orders/positions returns broker truth. Fake-only tests cover adversarial event delivery.
+
+## Tasks
+
+- [ ] 1. `execution/broker.py` Protocol + request/result value objects + capabilities.
+- [ ] 2. `FakeBroker` with scriptable fills/partials/rejects/event-ordering.
+- [ ] 3. `AlpacaPaperBroker`: submit_bracket/cancel/flatten/query; pick FIX or WS+REST and wire order events.
+- [ ] 4. Hook broker acks/fills into the Wave-1 ledger transitions.
+- [ ] 5. Shared broker contract suite + fake-only adversarial tests.
+- [ ] 6. ruff / mypy --strict / pytest green; CI green.
+
+## Claude Code prompt
+
+```
+Implement plans/waves/WAVE-02-broker-port.md in the ross-trading repo on a new feature
+branch. Define a broker-agnostic BrokerClient Protocol (mirroring the MarketDataProvider /
+DecisionSink Protocol pattern already in the repo) with an idempotent
+submit_bracket(client_order_id, ...) that realizes the architecture §3.6 atomic OCO
+bracket, plus cancel, flatten, order_events, get_open_orders, get_positions. Implement two
+adapters behind it: a deterministic in-memory FakeBroker (scriptable fills, partials,
+rejects, and out-of-order/dropped events) and an AlpacaPaperBroker against the paper
+endpoint. Do NOT treat Alpaca's order JSON WebSocket as source of truth (it has no sequence
+numbers); consume order events via FIX, or treat the WS as a hint with REST /orders and
+/positions authoritative. Wire broker acks/fills into the Wave-1 Ledger. Nothing above the
+port may import a vendor symbol. Write one shared contract test suite parametrized over
+both adapters. Work task-by-task; done when the advance_gate holds and CI is green.
+```

--- a/plans/waves/WAVE-03-risk-supervisor.md
+++ b/plans/waves/WAVE-03-risk-supervisor.md
@@ -1,7 +1,7 @@
 ---
 wave: 3
 title: Risk supervisor / kill switch
-depends_on: [1]
+depends_on: [1, 2]
 advance_gate: "safety/ package enforces daily max-loss, 3-consecutive-loser lock, single-position-at-a-time, PDT and T+1 cash-settlement guards; a force-flatten authority exists (manual + automatic) and calls broker.flatten; the loop is gated by a day_locked()/can_trade() check before any entry; unit + integration tests (against FakeBroker) green; mypy --strict + ruff + pytest green."
 status: not_started
 ---
@@ -12,7 +12,7 @@ status: not_started
 
 **Goal:** Build the risk supervisor / kill switch specified in §3.8 and §5 of `docs/architecture.md`, which today is an empty `safety/` package. It is the authority that can refuse new entries and force-flatten everything, and it must exist (with manual force-flatten at minimum) before the system is trusted with real size.
 
-**Why before reconciliation/wiring:** The kill switch is the blast-radius limiter. Building it early — against the Ledger (Wave 1) and `FakeBroker` (available once Wave 2 lands, but the gate only needs Wave 1) — means every later integration runs under a supervisor that can stop it.
+**Why before reconciliation/wiring:** The kill switch is the blast-radius limiter. Building it early — against the Ledger (Wave 1) and the `broker.flatten` / `FakeBroker` interfaces (Wave 2), both of which the advance gate exercises — means every later integration runs under a supervisor that can stop it.
 
 ## Decisions carried in
 

--- a/plans/waves/WAVE-03-risk-supervisor.md
+++ b/plans/waves/WAVE-03-risk-supervisor.md
@@ -1,0 +1,103 @@
+---
+wave: 3
+title: Risk supervisor / kill switch
+depends_on: [1]
+advance_gate: "safety/ package enforces daily max-loss, 3-consecutive-loser lock, single-position-at-a-time, PDT and T+1 cash-settlement guards; a force-flatten authority exists (manual + automatic) and calls broker.flatten; the loop is gated by a day_locked()/can_trade() check before any entry; unit + integration tests (against FakeBroker) green; mypy --strict + ruff + pytest green."
+status: not_started
+---
+
+# Wave 3 — Risk supervisor / kill switch
+
+> **For agentic workers:** implement task-by-task; `- [ ]` checkboxes. This is the highest-leverage safety component — the `safety/` package is currently empty.
+
+**Goal:** Build the risk supervisor / kill switch specified in §3.8 and §5 of `docs/architecture.md`, which today is an empty `safety/` package. It is the authority that can refuse new entries and force-flatten everything, and it must exist (with manual force-flatten at minimum) before the system is trusted with real size.
+
+**Why before reconciliation/wiring:** The kill switch is the blast-radius limiter. Building it early — against the Ledger (Wave 1) and `FakeBroker` (available once Wave 2 lands, but the gate only needs Wave 1) — means every later integration runs under a supervisor that can stop it.
+
+## Decisions carried in
+
+- **Pure decision core, side-effecting actuator.** A pure `RiskSupervisor.evaluate(state) -> Verdict` (testable, replay-safe) plus an actuator that performs `broker.flatten` / lock writes. Keeps determinism intact.
+- **Hard gates enforced in code, not delegated to broker:** daily max-loss, 3-consecutive-loser lock, single-position-at-a-time, PDT (margin <$25k), T+1 cash-settlement.
+- **Force-flatten authority** is the kill switch: a manual trigger (operator) and automatic triggers (limits breached, reconciliation divergence from Wave 4). It calls `broker.flatten` and writes a lock so no new entries pass.
+- **Fail-closed.** On unknown/ambiguous state (e.g. can't read positions), the supervisor blocks new entries rather than allowing them.
+- **Decimal money math.** PnL/limits in `Decimal`; share/sizing inputs `int`.
+
+## Scope
+
+In: `safety/` package (supervisor core, limits config, actuator, day-lock persistence), a `can_trade()`/`day_locked()` gate consumed by the loop, journal rows for risk events/locks, tests.
+Out: the reconciliation loop itself (Wave 4 — but expose the hook the supervisor's automatic flatten will use), full trading-loop wiring (Wave 5). Position sizing lives with execution; the supervisor only *checks*.
+
+## Files to add / change
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/ross_trading/safety/__init__.py` | Package init. |
+| Create | `src/ross_trading/safety/supervisor.py` | Pure `RiskSupervisor.evaluate(state) -> Verdict`; all hard gates. |
+| Create | `src/ross_trading/safety/limits.py` | Typed limits config (max daily loss, loser-streak, PDT/T+1 params). |
+| Create | `src/ross_trading/safety/actuator.py` | Force-flatten (manual + auto) via `broker.flatten`; writes day-lock. |
+| Create | `src/ross_trading/safety/state.py` | `RiskState` assembled from ledger positions/PnL + account/PDT counters. |
+| Edit | `src/ross_trading/journal/models.py` | `risk_events` / `day_locks` tables (audit of every block/flatten/lock). |
+| Edit | `src/ross_trading/scanner/loop.py` (or new exec loop placeholder) | Add `can_trade()` gate before any entry path. |
+| Create | `tests/unit/test_risk_supervisor.py` | Each gate fires correctly; fail-closed on unknown state. |
+| Create | `tests/integration/test_kill_switch.py` | Manual + automatic flatten against FakeBroker; lock blocks subsequent entries. |
+
+## Key interfaces (sketch)
+
+```python
+# safety/supervisor.py
+@dataclass(frozen=True, slots=True)
+class Verdict:
+    allow_new_entry: bool
+    must_flatten: bool
+    reasons: tuple[str, ...]          # audit trail, journaled
+
+class RiskSupervisor:
+    def evaluate(self, state: RiskState) -> Verdict: ...   # pure
+    # gates: daily_loss <= max; loser_streak < 3; open_positions <= 1;
+    #        pdt_ok(account); cash_settled_ok(T+1); else fail-closed
+
+# safety/actuator.py
+class KillSwitch:
+    def force_flatten(self, reason: str) -> None: ...       # broker.flatten all + write day-lock
+    def is_locked(self) -> bool: ...
+```
+
+## Acceptance criteria
+
+- [ ] `evaluate` is pure and deterministic; given a `RiskState` it returns the same `Verdict` every time, with human-readable `reasons`.
+- [ ] Each hard gate is independently tested: daily max-loss, 3-loser lock, single-position, PDT, T+1 cash settlement.
+- [ ] Fail-closed: missing/ambiguous state yields `allow_new_entry=False`.
+- [ ] `KillSwitch.force_flatten` (manual and automatic) flattens via `broker.flatten` and persists a day-lock; `can_trade()` returns False afterward.
+- [ ] Every block/flatten/lock is journaled to `risk_events`/`day_locks` with its reason.
+- [ ] The loop calls `can_trade()` before any entry; a locked day admits no entries.
+- [ ] mypy `--strict`, ruff, pytest green; CI green.
+
+## Test strategy
+
+Unit-test the pure supervisor across a matrix of states (each limit at/over threshold, combinations, unknown). Integration-test the kill switch against `FakeBroker`: open a position, trigger manual flatten, assert position closed + day locked + next entry refused. Add an automatic-trigger test simulating a max-loss breach.
+
+## Tasks
+
+- [ ] 1. `safety/limits.py` + `safety/state.py` (RiskState from ledger + account counters).
+- [ ] 2. `safety/supervisor.py` pure evaluate() with all hard gates + fail-closed.
+- [ ] 3. `safety/actuator.py` KillSwitch force-flatten (manual + auto) + day-lock persistence.
+- [ ] 4. `risk_events`/`day_locks` journal tables + migration.
+- [ ] 5. `can_trade()` gate in the loop before entries.
+- [ ] 6. Unit (supervisor matrix) + integration (kill switch vs FakeBroker) tests.
+- [ ] 7. ruff / mypy --strict / pytest green; CI green.
+
+## Claude Code prompt
+
+```
+Implement plans/waves/WAVE-03-risk-supervisor.md in the ross-trading repo on a new feature
+branch. Build the risk supervisor / kill switch in the currently-empty safety/ package per
+docs/architecture.md §3.8 and §5. Provide a PURE RiskSupervisor.evaluate(state)->Verdict
+enforcing hard gates in code (daily max-loss, 3-consecutive-loser lock,
+single-position-at-a-time, PDT for margin <$25k, T+1 cash settlement), fail-closed on
+unknown state, with human-readable reasons. Add a KillSwitch actuator with manual and
+automatic force-flatten that calls broker.flatten and writes a persisted day-lock, plus a
+can_trade()/day_locked() gate the loop checks before any entry. Journal every
+block/flatten/lock to new risk_events/day_locks tables. Money math in Decimal. Unit-test
+the supervisor across a state matrix and integration-test the kill switch against the
+FakeBroker from Wave 2. Work task-by-task; done when the advance_gate holds and CI is green.
+```

--- a/plans/waves/WAVE-04-reconciliation.md
+++ b/plans/waves/WAVE-04-reconciliation.md
@@ -1,0 +1,94 @@
+---
+wave: 4
+title: Reconciliation (broker truth)
+depends_on: [2, 3]
+advance_gate: "a reconciliation pass asserts ledger == broker positions/open-orders on a cadence AND on every restart; in-flight orders are recovered on startup; any divergence raises an alarm and triggers the kill switch; integration tests against FakeBroker (including injected divergence + crash-recovery) green; mypy --strict + ruff + pytest green."
+status: not_started
+---
+
+# Wave 4 — Reconciliation (broker truth)
+
+> **For agentic workers:** implement task-by-task; `- [ ]` checkboxes. This is what makes the kill switch and force-flatten *trustworthy*.
+
+**Goal:** Make broker state authoritative. Add a reconciliation pass that compares the internal Ledger (Wave 1) against broker truth (`get_positions`/`get_open_orders` from Wave 2) on a fixed cadence and on every process restart, recovers in-flight orders, and on any divergence raises an alarm and trips the kill switch (Wave 3). Without this, "force-flatten authority" is meaningless because the bot's notion of position can silently diverge from the broker's — the worst failure class for a money-mover.
+
+**Why now:** It depends on both a broker port (truth source) and the kill switch (the action on divergence). It is the last must-do-before-live correctness brick.
+
+## Decisions carried in
+
+- **Broker is the source of truth** for positions and open orders; the Ledger is reconciled *to* it, never the reverse.
+- **Reconcile on cadence and on restart.** On startup, rebuild in-flight order state from the broker before the loop is allowed to trade (gate via Wave 3 `can_trade()` staying False until first successful reconcile).
+- **Divergence is fail-closed.** Any mismatch (unknown position, qty mismatch, orphan order) → alarm + `KillSwitch.force_flatten` + day-lock pending operator review.
+- **Idempotent recovery** keyed on `client_order_id`: re-adopt broker orders into the ledger without creating duplicates.
+- **Auditable.** Every reconcile run and every divergence is journaled.
+
+## Scope
+
+In: `execution/reconcile.py` (the pass + startup recovery), wiring into startup + a periodic scheduler, journal rows for reconcile runs/divergences, alarm hook to the kill switch, tests.
+Out: the trading loop body itself (Wave 5 consumes `can_trade()` which now also depends on a clean reconcile), new vendors.
+
+## Files to add / change
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/ross_trading/execution/reconcile.py` | `Reconciler.run()` (cadence) + `Reconciler.recover_on_startup()`; diff ledger vs broker; emit divergences. |
+| Edit | `src/ross_trading/execution/ledger.py` | `adopt(broker_order)` idempotent on `client_order_id`; `snapshot()` for diffing. |
+| Edit | `src/ross_trading/safety/actuator.py` | Accept reconciliation divergence as an automatic force-flatten trigger. |
+| Edit | `src/ross_trading/journal/models.py` | `reconcile_runs` / `reconcile_divergences` tables. |
+| Edit | `src/ross_trading/core/clock.py` (or scheduler) | Cadence hook for periodic reconcile (injectable `Clock`, replay-safe). |
+| Create | `tests/integration/test_reconciliation.py` | Clean reconcile; injected divergence → flatten+lock; crash mid-flight → startup recovery; idempotent adopt. |
+
+## Key interfaces (sketch)
+
+```python
+# execution/reconcile.py
+@dataclass(frozen=True, slots=True)
+class Divergence:
+    kind: Literal["missing_position", "qty_mismatch", "orphan_broker_order",
+                  "orphan_ledger_order", "state_mismatch"]
+    ticker: str
+    detail: str
+
+class Reconciler:
+    def recover_on_startup(self) -> list[Divergence]: ...   # adopt broker truth before trading
+    def run(self) -> list[Divergence]: ...                  # cadence; [] == clean
+    # on any Divergence: journal + KillSwitch.force_flatten("reconcile:<kind>")
+```
+
+## Acceptance criteria
+
+- [ ] A clean state reconciles to `[]` (no divergence) on cadence and at startup.
+- [ ] Startup recovery adopts broker open orders/positions into the ledger idempotently (no dup rows) and only then allows `can_trade()` to become True.
+- [ ] Injected divergence (qty mismatch, orphan order, missing position) → journaled `Divergence` + automatic `force_flatten` + day-lock.
+- [ ] A simulated crash between "sent" and "ack" is resolved on next startup by reading broker truth.
+- [ ] Every reconcile run + divergence is journaled (`reconcile_runs`/`reconcile_divergences`).
+- [ ] mypy `--strict`, ruff, pytest green; CI green.
+
+## Test strategy
+
+Integration against `FakeBroker`: (1) ledger and broker agree → clean; (2) script broker to report an extra/missing position → expect flatten+lock; (3) write an `intended`/`sent` order, drop the ack, restart → expect recovery adopts the broker order; (4) run `adopt` twice → one row. Assert `can_trade()` is gated on a successful startup reconcile.
+
+## Tasks
+
+- [ ] 1. `Ledger.snapshot()` + idempotent `adopt(broker_order)`.
+- [ ] 2. `Reconciler.recover_on_startup()` adopting broker truth; gate `can_trade()` on it.
+- [ ] 3. `Reconciler.run()` cadence diff via injectable Clock.
+- [ ] 4. Divergence → journal + automatic kill-switch flatten (extend actuator triggers).
+- [ ] 5. `reconcile_runs`/`reconcile_divergences` tables + migration.
+- [ ] 6. Integration tests (clean / divergence / crash-recovery / idempotent adopt).
+- [ ] 7. ruff / mypy --strict / pytest green; CI green.
+
+## Claude Code prompt
+
+```
+Implement plans/waves/WAVE-04-reconciliation.md in the ross-trading repo on a new feature
+branch. Add a Reconciler that treats the broker as the source of truth: on every restart it
+recovers in-flight orders/positions from get_open_orders/get_positions and adopts them into
+the Wave-1 Ledger idempotently (keyed on client_order_id) before can_trade() is allowed to
+return True; on a fixed injectable-Clock cadence it diffs ledger vs broker and, on ANY
+divergence (qty mismatch, orphan order, missing/extra position), journals the divergence and
+triggers the Wave-3 KillSwitch force-flatten plus a day-lock (fail-closed). Add
+reconcile_runs/reconcile_divergences tables. Integration-test against the FakeBroker:
+clean reconcile, injected divergence, crash-between-sent-and-ack recovery, and idempotent
+adopt. Work task-by-task; done when the advance_gate holds and CI is green.
+```

--- a/plans/waves/WAVE-05-live-wiring-exits.md
+++ b/plans/waves/WAVE-05-live-wiring-exits.md
@@ -1,0 +1,96 @@
+---
+wave: 5
+title: Live signal->order wiring + event-driven exit monitor
+depends_on: [2, 3, 4]
+advance_gate: "trading_loop wires scanner->pattern->sizer->risk-checks->execution.place_bracket_order; a position-management/exit monitor consumes the broker order-event stream AND the quote stream directly (no polling for fill state); position sizer is Decimal/int end-to-end; full path runs end-to-end against FakeBroker in an integration test; mypy --strict + ruff + pytest green."
+status: not_started
+---
+
+# Wave 5 — Live signal->order wiring + event-driven exit monitor
+
+> **For agentic workers:** implement task-by-task; `- [ ]` checkboxes. This connects the (now-correct) signal path to the (now-safe) execution path.
+
+**Goal:** Wire the end-to-end real-time path the architecture specifies (`docs/architecture.md` §4): a `trading_loop` that gates on hours + `can_trade()` (Wave 3) then runs scanner -> pattern detector -> position sizer -> risk checks -> `execution.place_bracket_order(...)`, and a `position_management` / exit monitor that flattens on §3.7 triggers. Critically, the exit monitor consumes the broker **order-event stream** (fills/partials, from Wave 2) and the **quote stream directly** for millisecond reaction — it must NOT poll, and must NOT wait for the ~2s scanner tick to learn its fill state or hit a hard stop.
+
+**Why after 2/3/4:** Entries only make sense once they can be placed safely (broker port), supervised (kill switch), and trusted (reconciliation). This wave assembles them.
+
+## Decisions carried in
+
+- **Two consumers, one buffer.** The ~2s scanner loop reads the assembled as-of snapshot (unchanged from today). The exit monitor subscribes to the buffered quote stream + the broker order-event stream and reacts on arrival.
+- **Event-driven, not polling.** A fill/partial/stop can occur between polls; consume the order-event stream (FIX-sequenced or WS+reconcile) for state transitions. Poll only as a backstop.
+- **Position sizer is Decimal/int end-to-end.** Replace any float `risk_pct` math (`architecture.md` §3.5) so share counts can't drift from the ledger's Decimal columns; `shares = floor(max_risk / stop_distance)`.
+- **Every entry passes the supervisor.** `place_bracket_order` is only called when `Verdict.allow_new_entry` and `can_trade()` are both true; the bracket uses the Wave-1 `client_order_id`.
+- **Exits respect the bracket.** Server-side stop/target from the bracket are primary; the monitor's discretionary §3.7 exits (jackknife/MACD/volume-dry-up, L2 proxy) issue `flatten`/cancel through the port.
+
+## Scope
+
+In: `execution/sizer.py` (Decimal sizing), `execution/runtime.py` (the two loops), exit-trigger evaluation reusing completed-bar stats from the assembler + live quotes, wiring to ledger/supervisor/reconciler, integration tests on FakeBroker.
+Out: detector internals (separate Phase-4 pattern atoms), live (non-paper) capital, the parity CI gate + paid data (Wave 6). Use the L2 *proxy* (spread+size) for the §3.7 L2 exit; real L2/MBP-10 is deferred.
+
+## Files to add / change
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/ross_trading/execution/sizer.py` | `position_size(signal, account, risk_pct) -> int` in Decimal/int; §6 capacity cap via `avg_1min_volume`. |
+| Create | `src/ross_trading/execution/runtime.py` | `trading_loop()` + `position_management_loop()` (the §4 orchestration). |
+| Create | `src/ross_trading/execution/exits.py` | §3.7 exit triggers over completed bars + live quotes; emits flatten/cancel. |
+| Edit | `src/ross_trading/execution/ledger.py` | `place_bracket_order` convenience that records intent then calls `broker.submit_bracket`. |
+| Edit | `src/ross_trading/scanner/loop.py` | Factor shared snapshot/clock so both loops share one buffer; keep scanner tick intact. |
+| Create | `tests/integration/test_trading_path.py` | scanner pick -> signal -> sized -> risk-checked -> bracket placed -> partial fill -> exit, all on FakeBroker. |
+| Create | `tests/unit/test_sizer.py` | Decimal sizing + capacity cap; no float. |
+
+## Key interfaces (sketch)
+
+```python
+# execution/runtime.py
+async def trading_loop(deps) -> None:
+    # gate: market hours and supervisor.can_trade()
+    # snapshot -> scanner -> detector -> sizer -> supervisor.evaluate
+    # if allow_new_entry: ledger.place_bracket_order(BracketRequest(...))
+
+async def position_management_loop(deps) -> None:
+    async for ev in merge(broker.order_events(), quote_stream):
+        # update ledger on fills/partials; eval §3.7 exits on each quote/bar-close
+        # on trigger: broker.flatten(ticker) / cancel siblings
+```
+
+## Acceptance criteria
+
+- [ ] `trading_loop` only places an entry when market hours + `can_trade()` + `Verdict.allow_new_entry` all hold; the bracket carries a Wave-1 `client_order_id`.
+- [ ] Sizer is Decimal/int end-to-end; capacity cap uses `avg_1min_volume`; no `float`.
+- [ ] Exit monitor reacts to fills/partials from the order-event stream and to hard-stop crosses on the live quote — without waiting for the 2s tick and without polling for fill state.
+- [ ] A partial fill mid-position is reflected in the ledger before the scale-out/exit logic runs.
+- [ ] End-to-end integration test passes on FakeBroker (pick -> bracket -> partial -> exit -> flat), with the supervisor and reconciler in the loop.
+- [ ] mypy `--strict`, ruff, pytest green; CI green.
+
+## Test strategy
+
+One integration test drives a scripted FakeBroker + synthetic quote/bar stream through the full path and asserts: correct sizing, supervisor gating, bracket placement, partial-fill ledger update, an exit trigger firing on a quote between ticks, and a flat end state reconciling clean. Unit-test the sizer's Decimal math and capacity cap.
+
+## Tasks
+
+- [ ] 1. `execution/sizer.py` Decimal/int sizing + §6 capacity cap.
+- [ ] 2. `execution/exits.py` §3.7 triggers (bar-stat + quote-cross + L2 proxy).
+- [ ] 3. `ledger.place_bracket_order` (intent -> submit_bracket).
+- [ ] 4. `execution/runtime.py` trading_loop + event-driven position_management_loop (merge order-events + quotes).
+- [ ] 5. Share one snapshot/clock buffer between scanner tick and exit monitor.
+- [ ] 6. Integration test (full path on FakeBroker) + sizer unit tests.
+- [ ] 7. ruff / mypy --strict / pytest green; CI green.
+
+## Claude Code prompt
+
+```
+Implement plans/waves/WAVE-05-live-wiring-exits.md in the ross-trading repo on a new
+feature branch. Wire the end-to-end real-time path from docs/architecture.md §4: a
+trading_loop that gates on market hours and the Wave-3 can_trade()/supervisor verdict, then
+runs scanner -> pattern detector -> position sizer -> risk check ->
+ledger.place_bracket_order (using the Wave-1 client_order_id and Wave-2 submit_bracket); and
+a position_management_loop / exit monitor that consumes the broker order-event stream AND
+the live quote stream directly (NO polling for fill state, NO waiting for the ~2s scanner
+tick) to update the ledger on fills/partials and fire §3.7 exits via broker.flatten/cancel.
+Make the position sizer Decimal/int end-to-end (remove float risk_pct math) with the §6
+capacity cap on avg_1min_volume. Use the spread+size L2 proxy for the L2-weakness exit
+(real L2 is deferred). Keep the existing scanner tick intact; share one snapshot/clock
+buffer. Integration-test the full path on the FakeBroker with the supervisor and reconciler
+in the loop. Work task-by-task; done when the advance_gate holds and CI is green.
+```

--- a/plans/waves/WAVE-06-go-live-gate.md
+++ b/plans/waves/WAVE-06-go-live-gate.md
@@ -1,0 +1,83 @@
+---
+wave: 6
+title: Go-live gate — paid SIP data, parity CI, paper soak
+depends_on: [0, 5]
+advance_gate: "a full-SIP real-time feed is wired behind MarketDataProvider (IEX-only rejected); a bit-identical live-vs-replay decision test runs in CI as a hard merge gate; daily float refresh (<07:00 ET) is verified; a documented micro-stakes paper soak runbook + observability/metrics exist; CI green. NO real capital until this wave's checklist is signed off."
+status: not_started
+---
+
+# Wave 6 — Go-live gate: paid SIP data, parity CI, paper soak
+
+> **For agentic workers:** implement task-by-task; `- [ ]` checkboxes. This is the gate between "works on paper" and "trusted with real dollars."
+
+**Goal:** Close the operational + data-quality gap before live capital. Wire a full-SIP real-time feed (the scanner's rel-volume signal is meaningless on IEX-only ~2% volume), promote the live-vs-replay parity test (Wave 0) into a hard CI merge gate, verify daily float refresh (decision #33), and produce a micro-stakes paper-soak runbook with observability. This is the realization of the review's "must-do-before-live" set.
+
+**Why last:** It depends on a correct ingestion contract (Wave 0) and a working end-to-end path (Wave 5). It is mostly wiring, verification, and operability — plus the explicit decision gate.
+
+## Decisions carried in
+
+- **Full SIP is mandatory.** Start on Alpaca paid SIP (CTA+UTP, 100% volume) behind the existing `MarketDataProvider` Protocol. IEX-only / free tier is rejected as the signal source for low-float names. Keep the provider seam clean so a later swap to Databento (signal data) / IBKR (execution) is drop-in when a trigger fires.
+- **Parity is a merge gate.** The bit-identical live-vs-replay decision test becomes required CI — no merge to the live branch if a feed change breaks reproducibility.
+- **Float daily-refresh verified, else add a vendor.** Confirm the chosen feed refreshes float pre-07:00 ET daily; if not, add Polygon reference / Benzinga for float (decision #33) — the one second-vendor likely unavoidable.
+- **Observable before live.** Metrics/logs for order lifecycle, fills, positions, PnL, supervisor verdicts, reconcile runs, feed gaps/halts. A human can see what the bot is doing in real time.
+- **Switch triggers documented** (the at-scale upgrade path): replay parity unprovable on Alpaca's unsequenced WS; the §3.7 real-L2 exit gets built (needs MBP-10); measured slippage exceeds simulator; pre-market entries become core.
+
+## Scope
+
+In: a paid-SIP provider adapter behind `MarketDataProvider`, the parity-CI workflow, float-refresh verification + (if needed) a float vendor adapter, observability/metrics, a paper-soak runbook + go/no-go checklist.
+Out: real-capital trading (that is the operator's sign-off after this gate), the Databento/IBKR adapters themselves (future, trigger-driven — only the seam is kept clean here).
+
+## Files to add / change
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/ross_trading/data/providers/alpaca_sip.py` | Full-SIP real-time adapter behind `MarketDataProvider` (quotes/bars + seq/halt from Wave 0). |
+| Edit | `src/ross_trading/data/float_reference.py` | Verify/implement daily (<07:00 ET) float refresh; add vendor if Alpaca insufficient. |
+| Edit | `.github/workflows/*.yml` | Add `test_live_replay_parity` as a required gate on the live branch. |
+| Create | `src/ross_trading/observability/metrics.py` | Order/fill/position/PnL/supervisor/reconcile/feed metrics + structured logs. |
+| Create | `docs/runbook-paper-soak.md` | Micro-stakes paper-soak procedure + go/no-go checklist + switch triggers. |
+| Create | `tests/integration/test_sip_provider_contract.py` | SIP adapter honors the Wave-0 seq/halt/timestamp contract; volume completeness sanity check. |
+| Edit | `docs/architecture.md` | Mark #10/#11/#12/#33 resolutions + the documented switch triggers. |
+
+## Acceptance criteria
+
+- [ ] A full-SIP real-time feed is wired behind `MarketDataProvider` and emits the Wave-0 contract (`seq`, three timestamps, halts); IEX-only is not used as the signal source.
+- [ ] The SIP adapter passes the ingestion-contract tests; a volume-completeness check confirms it is not an IEX-sized slice.
+- [ ] The live-vs-replay bit-identical decision test is a **required** CI check on the live branch.
+- [ ] Float refresh is verified daily before 07:00 ET (or a float vendor is added and verified).
+- [ ] Observability exists: order lifecycle, fills, positions, PnL, supervisor verdicts, reconcile runs, feed gaps/halts are all visible in real time.
+- [ ] `docs/runbook-paper-soak.md` defines the micro-stakes soak + a go/no-go checklist + the documented switch triggers; the checklist is the explicit pre-live gate.
+- [ ] mypy `--strict`, ruff, pytest green; CI green (including the new parity gate).
+
+## Test strategy
+
+Contract-test the SIP adapter against the Wave-0 invariants and a volume sanity check. Verify the parity test fails CI if a feed change breaks reproducibility (deliberately break it once to prove the gate bites, then revert). Dry-run the runbook on the paper account end-to-end and capture the observability output.
+
+## Tasks
+
+- [ ] 1. `alpaca_sip.py` full-SIP adapter behind `MarketDataProvider` honoring the Wave-0 contract.
+- [ ] 2. SIP contract test + volume-completeness sanity check.
+- [ ] 3. Verify/implement daily float refresh (<07:00 ET); add float vendor if needed (#33).
+- [ ] 4. Promote `test_live_replay_parity` to a required CI gate on the live branch.
+- [ ] 5. Observability/metrics for the full order/risk/reconcile/feed lifecycle.
+- [ ] 6. `docs/runbook-paper-soak.md` + go/no-go checklist + switch triggers; record #10/#11/#12/#33 resolutions in architecture.md.
+- [ ] 7. ruff / mypy --strict / pytest green; CI green including the parity gate.
+
+## Claude Code prompt
+
+```
+Implement plans/waves/WAVE-06-go-live-gate.md in the ross-trading repo on a new feature
+branch. Wire a full-SIP real-time market-data adapter behind the existing
+MarketDataProvider Protocol (Alpaca paid SIP to start), honoring the Wave-0 ingestion
+contract (seq numbers, three timestamps, typed halts); IEX-only must NOT be the signal
+source. Keep the provider seam clean so a later swap to Databento (data) / IBKR (execution)
+is drop-in. Verify the float feed refreshes daily before 07:00 ET and add a float vendor if
+not (decision #33). Promote the Wave-0 live-vs-replay bit-identical decision test to a
+REQUIRED CI gate on the live branch (prove it bites by breaking it once, then revert). Add
+observability/metrics covering the order/fill/position/PnL/supervisor/reconcile/feed
+lifecycle. Write docs/runbook-paper-soak.md with a micro-stakes paper-soak procedure, an
+explicit go/no-go pre-live checklist, and the documented switch triggers. Record the
+#10/#11/#12/#33 resolutions in docs/architecture.md. This wave is the gate before real
+capital — do not enable live trading. Work task-by-task; done when the advance_gate holds
+and CI is green.
+```


### PR DESCRIPTION
Dependency-ordered waves (0-6) to take the trade-execution path from
spec to live, runnable in a Claude Code loop. Each wave is self-contained
(goal, file scope, acceptance criteria, advance gate, paste-ready prompt).
Includes README loop contract and HANDOFF with decision rationale.
