### PR TITLE
docs(plans): sync README wave table — Wave 3 depends on [1, 2]

### DIFF
--- a/plans/waves/README.md
+++ b/plans/waves/README.md
@@ -34,7 +34,7 @@ A driver loop should:
 | 0 | Ingestion contract correctness | — | `(ts,seq)` ordering + seq-gap detection + halt/correction events; live-vs-replay parity test green |
 | 1 | Execution domain model & ledger | 0 | orders/fills/positions tables + state machine + idempotency, migration applies, unit tests green |
 | 2 | Broker port + Fake + paper adapter | 1 | `BrokerClient` Protocol + `FakeBroker` + `AlpacaPaperBroker`; idempotent `submit_bracket`; contract tests green |
-| 3 | Risk supervisor / kill switch | 1 | `safety/` enforces max-loss, loser-lock, single-position, PDT/T+1; force-flatten; loop-gated; tests green |
+| 3 | Risk supervisor / kill switch | 1, 2 | `safety/` enforces max-loss, loser-lock, single-position, PDT/T+1; force-flatten; loop-gated; tests green |
 | 4 | Reconciliation (broker truth) | 2, 3 | startup + cadence reconcile ledger vs broker; divergence → kill switch; recovery test green |
 | 5 | Live signal→order wiring + event-driven exits | 2, 3, 4 | trading + position-management loops wired; exits consume order-event + quote streams (no polling); sizer Decimal/int; integration tests green on FakeBroker |
 | 6 | Go-live gate: paid SIP data, parity CI, paper soak | 0, 5 | full-SIP feed wired; bit-identical live-vs-replay CI gate enforced; float daily-refresh verified; micro-stakes paper soak runbook |


### PR DESCRIPTION
## Summary

Follow-up to #106. The WAVE-03 frontmatter declares `depends_on: [1, 2]` — the advance gate exercises `broker.flatten` and the `FakeBroker` integration tests introduced by Wave 2 — but the README "Order & gates" summary table still listed only Wave 1 for Wave 3. This aligns the table with the authoritative frontmatter so a driver loop and a human reader agree.

## Change

- `plans/waves/README.md`: Wave 3 "Depends on" column `1` → `1, 2`.

Docs-only, one line. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B64emhMuexu489Xe4F3iR2)_